### PR TITLE
Add SourceLink.Copy.PdbFiles to add missing .pdb files

### DIFF
--- a/S7.Net/S7.Net.csproj
+++ b/S7.Net/S7.Net.csproj
@@ -23,5 +23,6 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All" />
+    <PackageReference Include="SourceLink.Copy.PdbFiles" Version="2.8.3" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The PDB files are the missing part to allow debugging in VS without having local sources for S7NetPlus.