### PR TITLE
Fixed size calculation issues when reading and writing arrays

### DIFF
--- a/S7.Net.UnitTest/Helpers/TestClassUnevenSize.cs
+++ b/S7.Net.UnitTest/Helpers/TestClassUnevenSize.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace S7.Net.UnitTest.Helpers
+{
+    public class TestClassUnevenSize
+    {
+        public bool Bool { get; set; }
+        public byte[] Bytes { get; set; }
+        public bool[] Bools { get; set; }
+
+        public TestClassUnevenSize(int byteCount, int bitCount)
+        {
+            Bytes = new byte[byteCount];
+            Bools = new bool[bitCount];
+        }
+    }
+}

--- a/S7.Net.UnitTest/S7.Net.UnitTest.csproj
+++ b/S7.Net.UnitTest/S7.Net.UnitTest.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <Compile Include="ConnectionRequestTest.cs" />
     <Compile Include="ConvertersUnitTest.cs" />
+    <Compile Include="Helpers\TestClassUnevenSize.cs" />
     <Compile Include="ProtocolTests.cs" />
     <Compile Include="Helpers\ConsoleManager.cs" />
     <Compile Include="Helpers\NativeMethods.cs" />
@@ -78,6 +79,7 @@
     <Compile Include="S7NetTestsSync.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helpers\TestLongStruct.cs" />
+    <Compile Include="TypeTests\ClassTests.cs" />
     <Compile Include="TypeTests\StringExTests.cs" />
     <Compile Include="TypeTests\StringTests.cs" />
   </ItemGroup>

--- a/S7.Net.UnitTest/TypeTests/ClassTests.cs
+++ b/S7.Net.UnitTest/TypeTests/ClassTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using S7.Net.Types;
+using S7.Net.UnitTest.Helpers;
+
+namespace S7.Net.UnitTest.TypeTests
+{
+    [TestClass]
+    public class ClassTests
+    {
+        [TestMethod]
+        public void GetClassSizeTest()
+        {
+            Assert.AreEqual(Class.GetClassSize(new TestClassUnevenSize(1, 1)), 6);
+            Assert.AreEqual(Class.GetClassSize(new TestClassUnevenSize(2, 15)), 6);
+            Assert.AreEqual(Class.GetClassSize(new TestClassUnevenSize(2, 16)), 6);
+            Assert.AreEqual(Class.GetClassSize(new TestClassUnevenSize(2, 17)), 8);
+            Assert.AreEqual(Class.GetClassSize(new TestClassUnevenSize(3, 15)), 8);
+            Assert.AreEqual(Class.GetClassSize(new TestClassUnevenSize(3, 17)), 10);
+        }
+    }
+}

--- a/S7.Net/Types/Class.cs
+++ b/S7.Net/Types/Class.cs
@@ -89,6 +89,8 @@ namespace S7.Net.Types
                         throw new Exception("Cannot determine size of class, because an array is defined which has no fixed size greater than zero.");
                     }
 
+                    // Array starts at even byte adress
+                    numBytes = IncreaseToEvenNumber(numBytes);
                     for (int i = 0; i < array.Length; i++)
                     {
                         numBytes = GetIncreasedNumberOfBytes(numBytes, elementType);
@@ -100,9 +102,7 @@ namespace S7.Net.Types
                 }
             }
             // enlarge numBytes to next even number because S7-Structs in a DB always will be resized to an even byte count
-            numBytes = Math.Ceiling(numBytes);
-            if ((numBytes / 2 - Math.Floor(numBytes / 2.0)) > 0)
-                numBytes++;
+            numBytes = IncreaseToEvenNumber(numBytes);
             return (int)numBytes;
         }
 
@@ -232,6 +232,7 @@ namespace S7.Net.Types
                 if (property.PropertyType.IsArray)
                 {
                     Array array = (Array)property.GetValue(sourceClass, null);
+                    numBytes = IncreaseToEvenNumber(numBytes);
                     Type elementType = property.PropertyType.GetElementType();
                     for (int i = 0; i < array.Length && numBytes < bytes.Length; i++)
                     {
@@ -326,6 +327,7 @@ namespace S7.Net.Types
             {
                 if (property.PropertyType.IsArray)
                 {
+                    numBytes = IncreaseToEvenNumber(numBytes);
                     Array array = (Array)property.GetValue(sourceClass, null);
                     Type elementType = property.PropertyType.GetElementType();
                     for (int i = 0; i < array.Length && numBytes < bytes.Length; i++)
@@ -339,6 +341,14 @@ namespace S7.Net.Types
                 }
             }
             return bytes;
+        }
+
+        private static double IncreaseToEvenNumber(double numBytes)
+        {
+            numBytes = Math.Ceiling(numBytes);
+            if ((numBytes / 2 - Math.Floor(numBytes / 2.0)) > 0)
+                numBytes++;
+            return numBytes;
         }
     }
 }

--- a/S7.Net/Types/Class.cs
+++ b/S7.Net/Types/Class.cs
@@ -345,10 +345,10 @@ namespace S7.Net.Types
 
         private static double IncreaseToEvenNumber(double numBytes)
         {
-            numBytes = Math.Ceiling(numBytes);
-            if ((numBytes / 2 - Math.Floor(numBytes / 2.0)) > 0)
-                numBytes++;
-            return numBytes;
+            var numBytesInt = (int)Math.Ceiling(numBytes);
+            if (numBytesInt % 2 > 0)
+                numBytesInt++;
+            return numBytesInt;
         }
     }
 }


### PR DESCRIPTION
Fixed size calculation issues for classes when reading and writing arrays, since those always start with an even address in S7 data blocks.