### PR TITLE
Changed varType of memory Bit in address parsing method

### DIFF
--- a/S7.Net.UnitTest/PLCAddressParsingTests.cs
+++ b/S7.Net.UnitTest/PLCAddressParsingTests.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using S7.Net.Types;
+using System;
+
+namespace S7.Net.UnitTest
+{
+    [TestClass]
+    public class PLCAddressParsingTests
+    {
+        [TestMethod]
+        public void T01_ParseM2000_1()
+        {
+            DataItem dataItem = DataItem.FromAddress("M2000.1");
+
+            Assert.AreEqual(dataItem.DataType, DataType.Memory, "Wrong datatype for M2000.1");
+            Assert.AreEqual(dataItem.DB , 0, "Wrong dbnumber for M2000.1");
+            Assert.AreEqual(dataItem.VarType, VarType.Bit, "Wrong vartype for M2000.1");
+            Assert.AreEqual(dataItem.StartByteAdr, 2000, "Wrong startbyte for M2000.1");
+            Assert.AreEqual(dataItem.BitAdr, 1, "Wrong bit for M2000.1");
+
+            
+        }
+
+    }
+}

--- a/S7.Net.UnitTest/PLCAddressParsingTests.cs
+++ b/S7.Net.UnitTest/PLCAddressParsingTests.cs
@@ -12,14 +12,23 @@ namespace S7.Net.UnitTest
         {
             DataItem dataItem = DataItem.FromAddress("M2000.1");
 
-            Assert.AreEqual(dataItem.DataType, DataType.Memory, "Wrong datatype for M2000.1");
-            Assert.AreEqual(dataItem.DB , 0, "Wrong dbnumber for M2000.1");
-            Assert.AreEqual(dataItem.VarType, VarType.Bit, "Wrong vartype for M2000.1");
-            Assert.AreEqual(dataItem.StartByteAdr, 2000, "Wrong startbyte for M2000.1");
-            Assert.AreEqual(dataItem.BitAdr, 1, "Wrong bit for M2000.1");
-
-            
+            Assert.AreEqual(DataType.Memory, dataItem.DataType, "Wrong datatype for M2000.1");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for M2000.1");
+            Assert.AreEqual(VarType.Bit, dataItem.VarType, "Wrong vartype for M2000.1");
+            Assert.AreEqual(2000, dataItem.StartByteAdr, "Wrong startbyte for M2000.1");
+            Assert.AreEqual(1, dataItem.BitAdr, "Wrong bit for M2000.1");
         }
 
+        [TestMethod]
+        public void T02_ParseMB200()
+        {
+            DataItem dataItem = DataItem.FromAddress("MB200");
+
+            Assert.AreEqual(DataType.Memory, dataItem.DataType, "Wrong datatype for MB200");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for MB200");
+            Assert.AreEqual(VarType.Byte, dataItem.VarType, "Wrong vartype for MB200");
+            Assert.AreEqual(200, dataItem.StartByteAdr, "Wrong startbyte for MB200");
+            Assert.AreEqual(0, dataItem.BitAdr, "Wrong bit for MB200");
+        }
     }
 }

--- a/S7.Net.UnitTest/S7.Net.UnitTest.csproj
+++ b/S7.Net.UnitTest/S7.Net.UnitTest.csproj
@@ -63,6 +63,7 @@
     <Compile Include="ConnectionRequestTest.cs" />
     <Compile Include="ConvertersUnitTest.cs" />
     <Compile Include="Helpers\TestClassWithNestedClass.cs" />
+    <Compile Include="PLCAddressParsingTests.cs" />
     <Compile Include="ProtocolTests.cs" />
     <Compile Include="Helpers\ConsoleManager.cs" />
     <Compile Include="Helpers\NativeMethods.cs" />

--- a/S7.Net/PLCAddress.cs
+++ b/S7.Net/PLCAddress.cs
@@ -161,7 +161,7 @@
                         case "M":
                             // Memory
                             dataType = DataType.Memory;
-                            varType = VarType.Byte;
+                            varType = VarType.Bit;
                             break;
                         case "T":
                             // Timer


### PR DESCRIPTION
I made a small adjustment to the `PLCAddress.Parse` method. Because when parsing address M2000.1 the method returned `varType = Byte`, while I was expecting `Bit`.

I changed this in the code and added a test for this.
Also, attached a screenshot of the online Siemens configuration. Here you can see that M2000.1 is really a bit.
![Screenshot](https://user-images.githubusercontent.com/21312711/71088533-f1975e80-219e-11ea-9dc1-7371a0f6b82a.PNG)
