### PR TITLE
Extended PLCAddress.Parse method

### DIFF
--- a/S7.Net.UnitTest/PLCAddressParsingTests.cs
+++ b/S7.Net.UnitTest/PLCAddressParsingTests.cs
@@ -1,0 +1,156 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using S7.Net.Types;
+using System;
+
+namespace S7.Net.UnitTest
+{
+    [TestClass]
+    public class PLCAddressParsingTests
+    {
+        [TestMethod]
+        public void T01_ParseM2000_1()
+        {
+            DataItem dataItem = DataItem.FromAddress("M2000.1");
+
+            Assert.AreEqual(DataType.Memory, dataItem.DataType, "Wrong datatype for M2000.1");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for M2000.1");
+            Assert.AreEqual(VarType.Bit, dataItem.VarType, "Wrong vartype for M2000.1");
+            Assert.AreEqual(2000, dataItem.StartByteAdr, "Wrong startbyte for M2000.1");
+            Assert.AreEqual(1, dataItem.BitAdr, "Wrong bit for M2000.1");
+        }
+
+        [TestMethod]
+        public void T02_ParseMB200()
+        {
+            DataItem dataItem = DataItem.FromAddress("MB200");
+
+            Assert.AreEqual(DataType.Memory, dataItem.DataType, "Wrong datatype for MB200");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for MB200");
+            Assert.AreEqual(VarType.Byte, dataItem.VarType, "Wrong vartype for MB200");
+            Assert.AreEqual(200, dataItem.StartByteAdr, "Wrong startbyte for MB200");
+            Assert.AreEqual(0, dataItem.BitAdr, "Wrong bit for MB200");
+        }
+
+        [TestMethod]
+        public void T03_ParseMW200()
+        {
+            DataItem dataItem = DataItem.FromAddress("MW200");
+
+            Assert.AreEqual(DataType.Memory, dataItem.DataType, "Wrong datatype for MW200");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for MW200");
+            Assert.AreEqual(VarType.Word, dataItem.VarType, "Wrong vartype for MW200");
+            Assert.AreEqual(200, dataItem.StartByteAdr, "Wrong startbyte for MW200");
+            Assert.AreEqual(0, dataItem.BitAdr, "Wrong bit for MW200");
+        }
+
+        [TestMethod]
+        public void T04_ParseMD200()
+        {
+            DataItem dataItem = DataItem.FromAddress("MD200");
+
+            Assert.AreEqual(DataType.Memory, dataItem.DataType, "Wrong datatype for MD200");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for MD200");
+            Assert.AreEqual(VarType.DWord, dataItem.VarType, "Wrong vartype for MD200");
+            Assert.AreEqual(200, dataItem.StartByteAdr, "Wrong startbyte for MD200");
+            Assert.AreEqual(0, dataItem.BitAdr, "Wrong bit for MD200");
+        }
+
+
+        [TestMethod]
+        public void T05_ParseI2000_1()
+        {
+            DataItem dataItem = DataItem.FromAddress("I2000.1");
+
+            Assert.AreEqual(DataType.Input, dataItem.DataType, "Wrong datatype for I2000.1");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for I2000.1");
+            Assert.AreEqual(VarType.Bit, dataItem.VarType, "Wrong vartype for I2000.1");
+            Assert.AreEqual(2000, dataItem.StartByteAdr, "Wrong startbyte for I2000.1");
+            Assert.AreEqual(1, dataItem.BitAdr, "Wrong bit for I2000.1");
+        }
+
+        [TestMethod]
+        public void T06_ParseIB200()
+        {
+            DataItem dataItem = DataItem.FromAddress("IB200");
+
+            Assert.AreEqual(DataType.Input, dataItem.DataType, "Wrong datatype for IB200");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for IB200");
+            Assert.AreEqual(VarType.Byte, dataItem.VarType, "Wrong vartype for IB200");
+            Assert.AreEqual(200, dataItem.StartByteAdr, "Wrong startbyte for IB200");
+            Assert.AreEqual(0, dataItem.BitAdr, "Wrong bit for IB200");
+        }
+
+        [TestMethod]
+        public void T07_ParseIW200()
+        {
+            DataItem dataItem = DataItem.FromAddress("IW200");
+
+            Assert.AreEqual(DataType.Input, dataItem.DataType, "Wrong datatype for IW200");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for IW200");
+            Assert.AreEqual(VarType.Word, dataItem.VarType, "Wrong vartype for IW200");
+            Assert.AreEqual(200, dataItem.StartByteAdr, "Wrong startbyte for IW200");
+            Assert.AreEqual(0, dataItem.BitAdr, "Wrong bit for IW200");
+        }
+
+        [TestMethod]
+        public void T08_ParseID200()
+        {
+            DataItem dataItem = DataItem.FromAddress("ID200");
+
+            Assert.AreEqual(DataType.Input, dataItem.DataType, "Wrong datatype for ID200");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for ID200");
+            Assert.AreEqual(VarType.DWord, dataItem.VarType, "Wrong vartype for ID200");
+            Assert.AreEqual(200, dataItem.StartByteAdr, "Wrong startbyte for ID200");
+            Assert.AreEqual(0, dataItem.BitAdr, "Wrong bit for ID200");
+        }
+
+
+        [TestMethod]
+        public void T09_ParseQ2000_1()
+        {
+            DataItem dataItem = DataItem.FromAddress("Q2000.1");
+
+            Assert.AreEqual(DataType.Output, dataItem.DataType, "Wrong datatype for Q2000.1");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for Q2000.1");
+            Assert.AreEqual(VarType.Bit, dataItem.VarType, "Wrong vartype for Q2000.1");
+            Assert.AreEqual(2000, dataItem.StartByteAdr, "Wrong startbyte for Q2000.1");
+            Assert.AreEqual(1, dataItem.BitAdr, "Wrong bit for Q2000.1");
+        }
+
+        [TestMethod]
+        public void T10_ParseQB200()
+        {
+            DataItem dataItem = DataItem.FromAddress("QB200");
+
+            Assert.AreEqual(DataType.Output, dataItem.DataType, "Wrong datatype for QB200");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for QB200");
+            Assert.AreEqual(VarType.Byte, dataItem.VarType, "Wrong vartype for QB200");
+            Assert.AreEqual(200, dataItem.StartByteAdr, "Wrong startbyte for QB200");
+            Assert.AreEqual(0, dataItem.BitAdr, "Wrong bit for QB200");
+        }
+
+        [TestMethod]
+        public void T11_ParseQW200()
+        {
+            DataItem dataItem = DataItem.FromAddress("QW200");
+
+            Assert.AreEqual(DataType.Output, dataItem.DataType, "Wrong datatype for QW200");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for QW200");
+            Assert.AreEqual(VarType.Word, dataItem.VarType, "Wrong vartype for QW200");
+            Assert.AreEqual(200, dataItem.StartByteAdr, "Wrong startbyte for QW200");
+            Assert.AreEqual(0, dataItem.BitAdr, "Wrong bit for QW200");
+        }
+
+        [TestMethod]
+        public void T12_ParseQD200()
+        {
+            DataItem dataItem = DataItem.FromAddress("QD200");
+
+            Assert.AreEqual(DataType.Output, dataItem.DataType, "Wrong datatype for QD200");
+            Assert.AreEqual(0, dataItem.DB, "Wrong dbnumber for QD200");
+            Assert.AreEqual(VarType.DWord, dataItem.VarType, "Wrong vartype for QD200");
+            Assert.AreEqual(200, dataItem.StartByteAdr, "Wrong startbyte for QD200");
+            Assert.AreEqual(0, dataItem.BitAdr, "Wrong bit for QD200");
+        }
+    }
+}

--- a/S7.Net.UnitTest/S7.Net.UnitTest.csproj
+++ b/S7.Net.UnitTest/S7.Net.UnitTest.csproj
@@ -63,6 +63,7 @@
     <Compile Include="ConnectionRequestTest.cs" />
     <Compile Include="ConvertersUnitTest.cs" />
     <Compile Include="Helpers\TestClassWithNestedClass.cs" />
+    <Compile Include="PLCAddressParsingTests.cs" />
     <Compile Include="ProtocolTests.cs" />
     <Compile Include="Helpers\ConsoleManager.cs" />
     <Compile Include="Helpers\NativeMethods.cs" />

--- a/S7.Net/PLCAddress.cs
+++ b/S7.Net/PLCAddress.cs
@@ -80,6 +80,7 @@
                         default:
                             throw new InvalidAddressException();
                     }
+                case "IB":
                 case "EB":
                     // Input byte
                     dataType = DataType.Input;
@@ -87,6 +88,7 @@
                     address = int.Parse(input.Substring(2));
                     varType = VarType.Byte;
                     return;
+                case "IW":
                 case "EW":
                     // Input word
                     dataType = DataType.Input;
@@ -94,6 +96,7 @@
                     address = int.Parse(input.Substring(2));
                     varType = VarType.Word;
                     return;
+                case "ID":
                 case "ED":
                     // Input double-word
                     dataType = DataType.Input;
@@ -101,6 +104,7 @@
                     address = int.Parse(input.Substring(2));
                     varType = VarType.DWord;
                     return;
+                case "QB":
                 case "AB":
                     // Output byte
                     dataType = DataType.Output;
@@ -108,6 +112,7 @@
                     address = int.Parse(input.Substring(2));
                     varType = VarType.Byte;
                     return;
+                case "QW":
                 case "AW":
                     // Output word
                     dataType = DataType.Output;
@@ -115,6 +120,7 @@
                     address = int.Parse(input.Substring(2));
                     varType = VarType.Word;
                     return;
+                case "QD":
                 case "AD":
                     // Output double-word
                     dataType = DataType.Output;
@@ -152,6 +158,7 @@
                             dataType = DataType.Input;
                             varType = VarType.Bit;
                             break;
+                        case "Q":
                         case "A":
                         case "O":
                             // Output
@@ -161,7 +168,7 @@
                         case "M":
                             // Memory
                             dataType = DataType.Memory;
-                            varType = VarType.Byte;
+                            varType = VarType.Bit;
                             break;
                         case "T":
                             // Timer


### PR DESCRIPTION
Extended `PLCAddress.Parse` method to incorporate also addresses starting with `I` and `Q` and changed `varType` of address Mxxx.x to `Bit` 

Refer to previous Pull request for more details: #245 