### PR TITLE
Fixed received data size checking to avoid IndexOutOfRange exception

### DIFF
--- a/S7.Net/PlcSynchronous.cs
+++ b/S7.Net/PlcSynchronous.cs
@@ -353,7 +353,7 @@ namespace S7.Net
                 stream.Write(package.Array, 0, package.Array.Length);
 
                 var s7data = COTP.TSDU.Read(stream);
-                if (s7data == null || s7data[14] != 0xff)
+                if (s7data == null || s7data.Length < 18 + count || s7data[14] != 0xff)
                     throw new PlcException(ErrorCode.WrongNumberReceivedBytes);
 
                 for (int cnt = 0; cnt < count; cnt++)


### PR DESCRIPTION
This fixes a problem when trying to read DB from a PLC which has "Permit access with PUT/GET communication from remote partner" option in "Protection & Security" unchecked.
