### PR TITLE
Adjust AssertPduSize checks for Reading multiple DataItems.

### DIFF
--- a/S7.Net/PLC.cs
+++ b/S7.Net/PLC.cs
@@ -183,10 +183,10 @@ namespace S7.Net
 
         private void AssertPduSizeForRead(ICollection<DataItem> dataItems)
         {
-            // 12 bytes of header data, 12 bytes of parameter data for each dataItem
-            if ((dataItems.Count + 1) * 12 > MaxPDUSize) throw new Exception("Too many vars requested for read");
+            // send request limit: 19 bytes of header data, 12 bytes of parameter data for each dataItem
+            if (19 + dataItems.Count * 12 > MaxPDUSize) throw new Exception("Too many vars requested for read");
             
-            // 14 bytes of header data, 4 bytes of result data for each dataItem and the actual data
+            // response limit: 14 bytes of header data, 4 bytes of result data for each dataItem and the actual data
             if (GetDataLength(dataItems) + dataItems.Count * 4 + 14 > MaxPDUSize) throw new Exception("Too much data requested for read");
         }
 

--- a/S7.Net/PLC.cs
+++ b/S7.Net/PLC.cs
@@ -184,10 +184,12 @@ namespace S7.Net
         private void AssertPduSizeForRead(ICollection<DataItem> dataItems)
         {
             // send request limit: 19 bytes of header data, 12 bytes of parameter data for each dataItem
-            if (19 + dataItems.Count * 12 > MaxPDUSize) throw new Exception("Too many vars requested for read");
-            
+            var requiredRequestSize = 19 + dataItems.Count * 12;
+            if (requiredRequestSize > MaxPDUSize) throw new Exception($"Too many vars requested for read. Request size ({requiredRequestSize}) is larger than protocol limit ({MaxPDUSize}).");
+
             // response limit: 14 bytes of header data, 4 bytes of result data for each dataItem and the actual data
-            if (GetDataLength(dataItems) + dataItems.Count * 4 + 14 > MaxPDUSize) throw new Exception("Too much data requested for read");
+            var requiredResponseSize = GetDataLength(dataItems) + dataItems.Count * 4 + 14;
+            if (requiredResponseSize > MaxPDUSize) throw new Exception($"Too much data requested for read. Response size ({requiredResponseSize}) is larger than protocol limit ({MaxPDUSize}).");
         }
 
         private void AssertPduSizeForWrite(ICollection<DataItem> dataItems)

--- a/S7.Net/PlcAsynchronous.cs
+++ b/S7.Net/PlcAsynchronous.cs
@@ -209,9 +209,9 @@ namespace S7.Net
         /// You have to create and pass a list of DataItems and you obtain in response the same list with the values.
         /// Values are stored in the property "Value" of the dataItem and are already converted.
         /// If you don't want the conversion, just create a dataItem of bytes. 
-        /// DataItems must not be more than 20 (protocol restriction) and bytes must not be more than 200 + 22 of header (protocol restriction).
+        /// The number of DataItems as well as the total size of the requested data can not exceed a certain limit (protocol restriction).
         /// </summary>
-        /// <param name="dataItems">List of dataitems that contains the list of variables that must be read. Maximum 20 dataitems are accepted.</param>
+        /// <param name="dataItems">List of dataitems that contains the list of variables that must be read.</param>
         public async Task<List<DataItem>> ReadMultipleVarsAsync(List<DataItem> dataItems)
         {
             //Snap7 seems to choke on PDU sizes above 256 even if snap7 

--- a/S7.Net/PlcSynchronous.cs
+++ b/S7.Net/PlcSynchronous.cs
@@ -500,13 +500,11 @@ namespace S7.Net
         /// You have to create and pass a list of DataItems and you obtain in response the same list with the values.
         /// Values are stored in the property "Value" of the dataItem and are already converted.
         /// If you don't want the conversion, just create a dataItem of bytes. 
-        /// DataItems must not be more than 20 (protocol restriction) and bytes must not be more than 200 + 22 of header (protocol restriction).
+        /// The number of DataItems as well as the total size of the requested data can not exceed a certain limit (protocol restriction).
         /// </summary>
-        /// <param name="dataItems">List of dataitems that contains the list of variables that must be read. Maximum 20 dataitems are accepted.</param>
+        /// <param name="dataItems">List of dataitems that contains the list of variables that must be read.</param>
         public void ReadMultipleVars(List<DataItem> dataItems)
         {
-            //Snap7 seems to choke on PDU sizes above 256 even if snap7 
-            //replies with bigger PDU size in connection setup.
             AssertPduSizeForRead(dataItems);
 
             var stream = GetStreamIfAvailable();


### PR DESCRIPTION
The limit calculations did not match what the send and parsing code expected.

sending request header seems to be 19 byte in general.

Also adjust XML comments somewhat, since max PDU really differs a lot between PLC types, from 240 to 960 afaik.