### PR TITLE
Fixed size reads version 2

### DIFF
--- a/S7.Net.UnitTest/ProtocolTests.cs
+++ b/S7.Net.UnitTest/ProtocolTests.cs
@@ -35,6 +35,33 @@ namespace S7.Net.UnitTest
         }
 
         [TestMethod]
+        public async Task TPKT_ReadDelayedAsync()
+        {
+            var fullMessage = ProtocolUnitTest.StringToByteArray("0300002902f0803203000000010002001400000401ff0400807710000100000103000000033f8ccccd");
+            var m = new MemoryStream();
+            m.Write(fullMessage, 0, 2);
+            var tcs = new TaskCompletionSource<bool>();
+            tcs.Task.ContinueWith(x => m.Write(fullMessage, 2, fullMessage.Length - 2));
+            var t = TPKT.ReadAsync(m);
+            tcs.TrySetResult(true);
+            await t;
+        }
+
+        [TestMethod]
+        public void TPKT_ReadDelayed()
+        {
+            var fullMessage = ProtocolUnitTest.StringToByteArray("0300002902f0803203000000010002001400000401ff0400807710000100000103000000033f8ccccd");
+            var m = new MemoryStream();
+            m.Write(fullMessage, 0, 2);
+            var tcs = new TaskCompletionSource<bool>();
+            tcs.Task.ContinueWith(x => m.Write(fullMessage, 2, fullMessage.Length - 2));
+
+            Task.Delay(TimeSpan.FromSeconds(0.01)).ContinueWith(x => tcs.TrySetResult(true));
+            var t = TPKT.Read(m);
+            tcs.TrySetResult(true);
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(TPKTInvalidException))]
         public async Task TPKT_ReadShortAsync()
         {

--- a/S7.Net.UnitTest/ProtocolTests.cs
+++ b/S7.Net.UnitTest/ProtocolTests.cs
@@ -34,32 +34,6 @@ namespace S7.Net.UnitTest
             var t = TPKT.Read(m);
         }
 
-        [TestMethod]
-        public async Task TPKT_ReadDelayedAsync()
-        {
-            var fullMessage = ProtocolUnitTest.StringToByteArray("0300002902f0803203000000010002001400000401ff0400807710000100000103000000033f8ccccd");
-            var m = new MemoryStream();
-            m.Write(fullMessage, 0, 2);
-            var tcs = new TaskCompletionSource<bool>();
-            tcs.Task.ContinueWith(x => m.Write(fullMessage, 2, fullMessage.Length - 2));
-            var t = TPKT.ReadAsync(m);
-            tcs.TrySetResult(true);
-            await t;
-        }
-
-        [TestMethod]
-        public void TPKT_ReadDelayed()
-        {
-            var fullMessage = ProtocolUnitTest.StringToByteArray("0300002902f0803203000000010002001400000401ff0400807710000100000103000000033f8ccccd");
-            var m = new MemoryStream();
-            m.Write(fullMessage, 0, 2);
-            var tcs = new TaskCompletionSource<bool>();
-            tcs.Task.ContinueWith(x => m.Write(fullMessage, 2, fullMessage.Length - 2));
-
-            Task.Delay(TimeSpan.FromSeconds(0.01)).ContinueWith(x => tcs.TrySetResult(true));
-            var t = TPKT.Read(m);
-            tcs.TrySetResult(true);
-        }
 
         [TestMethod]
         [ExpectedException(typeof(TPKTInvalidException))]
@@ -67,7 +41,7 @@ namespace S7.Net.UnitTest
         {
             var m = new MemoryStream(StringToByteArray("0300002902f0803203000000010002001400000401ff040080"));
             var t = await TPKT.ReadAsync(m);
-         }
+        }
 
         [TestMethod]
         public void COTP_ReadTSDU()
@@ -81,7 +55,7 @@ namespace S7.Net.UnitTest
             Assert.IsTrue(expected.SequenceEqual(t));
         }
 
-        private static byte[] StringToByteArray(string hex)
+        public static byte[] StringToByteArray(string hex)
         {
             return Enumerable.Range(0, hex.Length)
                              .Where(x => x % 2 == 0)
@@ -89,4 +63,5 @@ namespace S7.Net.UnitTest
                              .ToArray();
         }
     }
+
 }

--- a/S7.Net.UnitTest/StreamTests.cs
+++ b/S7.Net.UnitTest/StreamTests.cs
@@ -34,6 +34,10 @@ namespace S7.Net.UnitTest
         int _position = 0;
         public override int Read(byte[] buffer, int offset, int count)
         {
+            if (_position >= Data.Length)
+            {
+                return 0;
+            }
             buffer[offset] = Data[_position];
             ++_position;
             return 1;
@@ -80,6 +84,14 @@ namespace S7.Net.UnitTest
             var t = TPKT.Read(m);
             Assert.AreEqual(fullMessage.Length, t.Length);
             Assert.AreEqual(fullMessage.Last(), t.Data.Last());
+        }
+
+        [TestMethod]
+        public void TPKT_ReadStreamTooShort()
+        {
+            var fullMessage = ProtocolUnitTest.StringToByteArray("0300002902f0803203000000010002001400");
+            var m = new TestStream1BytePerRead(fullMessage);
+            Assert.ThrowsException<TPKTInvalidException>(() => TPKT.Read(m));
         }
     }
 }

--- a/S7.Net.UnitTest/StreamTests.cs
+++ b/S7.Net.UnitTest/StreamTests.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace S7.Net.UnitTest
+{
+    /// <summary>
+    /// Test stream which only gives 1 byte per read.
+    /// </summary>
+    class TestStream1BytePerRead : Stream
+    {
+        public TestStream1BytePerRead(byte[] data)
+        {
+            Data = data;
+        }
+        public override bool CanRead => _position < Data.Length;
+
+        public override bool CanSeek => throw new NotImplementedException();
+
+        public override bool CanWrite => throw new NotImplementedException();
+
+        public override long Length => throw new NotImplementedException();
+
+        public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public byte[] Data { get; }
+
+        public override void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        int _position = 0;
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            buffer[offset] = Data[_position];
+            ++_position;
+            return 1;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    [TestClass]
+    public class StreamTests
+    {
+
+        [TestMethod]
+        public async Task TPKT_ReadRestrictedStreamAsync()
+        {
+            var fullMessage = ProtocolUnitTest.StringToByteArray("0300002902f0803203000000010002001400000401ff0400807710000100000103000000033f8ccccd");
+            var m = new TestStream1BytePerRead(fullMessage);
+            var t = await TPKT.ReadAsync(m);
+            Assert.AreEqual(fullMessage.Length, t.Length);
+            Assert.AreEqual(fullMessage.Last(), t.Data.Last());
+        }
+
+        [TestMethod]
+        public void TPKT_ReadRestrictedStream()
+        {
+            var fullMessage = ProtocolUnitTest.StringToByteArray("0300002902f0803203000000010002001400000401ff0400807710000100000103000000033f8ccccd");
+            var m = new TestStream1BytePerRead(fullMessage);
+            var t = TPKT.Read(m);
+            Assert.AreEqual(fullMessage.Length, t.Length);
+            Assert.AreEqual(fullMessage.Last(), t.Data.Last());
+        }
+    }
+}

--- a/S7.Net.UnitTest/StreamTests.cs
+++ b/S7.Net.UnitTest/StreamTests.cs
@@ -55,6 +55,9 @@ namespace S7.Net.UnitTest
         }
     }
 
+    /// <summary>
+    /// These tests are intended to test <see cref="StreamExtensions"/> functions and other stream-related special cases.
+    /// </summary>
     [TestClass]
     public class StreamTests
     {

--- a/S7.Net/StreamExtensions.cs
+++ b/S7.Net/StreamExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -19,12 +19,11 @@ namespace S7.Net
         /// <returns>returns the amount of read bytes</returns>
         public static int ReadFixed(this Stream stream, byte[] buffer, int offset, int count)
         {
-            int read = offset;
+            int read = 0;
             int received;
-            count = Math.Min(count, buffer.Length - offset);
             do
             {
-                received = stream.Read(buffer, read, count - read);
+                received = stream.Read(buffer, offset + read, count - read);
                 read += received;
             }
             while (read < count && received > 0);
@@ -42,12 +41,11 @@ namespace S7.Net
         /// <returns>returns the amount of read bytes</returns>
         public static async Task<int> ReadFixedAsync(this Stream stream, byte[] buffer, int offset, int count)
         {
-            int read = offset;
+            int read = 0;
             int received;
-            count = Math.Min(count, buffer.Length - offset);
             do
             {
-                received = await stream.ReadAsync(buffer, read, count - read);
+                received = await stream.ReadAsync(buffer, offset + read, count - read);
                 read += received;
             }
             while (read < count && received > 0);

--- a/S7.Net/StreamExtensions.cs
+++ b/S7.Net/StreamExtensions.cs
@@ -10,14 +10,14 @@ namespace S7.Net
     public static class StreamExtensions
     {
         /// <summary>
-        /// Reads a fixed amount of bytes from the stream into the buffer
+        /// Reads bytes from the stream into the buffer until exactly the requested number of bytes (or EOF) have been read
         /// </summary>
         /// <param name="stream">the Stream to read from</param>
         /// <param name="buffer">the buffer to read into</param>
         /// <param name="offset">the offset in the buffer to read into</param>
         /// <param name="count">the amount of bytes to read into the buffer</param>
         /// <returns>returns the amount of read bytes</returns>
-        public static int ReadFixed(this Stream stream, byte[] buffer, int offset, int count)
+        public static int ReadExact(this Stream stream, byte[] buffer, int offset, int count)
         {
             int read = 0;
             int received;
@@ -32,14 +32,14 @@ namespace S7.Net
         }
 
         /// <summary>
-        /// Reads a fixed amount of bytes from the stream into the buffer
+        /// Reads bytes from the stream into the buffer until exactly the requested number of bytes (or EOF) have been read
         /// </summary>
         /// <param name="stream">the Stream to read from</param>
         /// <param name="buffer">the buffer to read into</param>
         /// <param name="offset">the offset in the buffer to read into</param>
         /// <param name="count">the amount of bytes to read into the buffer</param>
         /// <returns>returns the amount of read bytes</returns>
-        public static async Task<int> ReadFixedAsync(this Stream stream, byte[] buffer, int offset, int count)
+        public static async Task<int> ReadExactAsync(this Stream stream, byte[] buffer, int offset, int count)
         {
             int read = 0;
             int received;

--- a/S7.Net/StreamExtensions.cs
+++ b/S7.Net/StreamExtensions.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace S7.Net
+{
+    /// <summary>
+    /// Extensions for Streams
+    /// </summary>
+    public static class StreamExtensions
+    {
+        /// <summary>
+        /// Reads a fixed amount of bytes from the stream into the buffer
+        /// </summary>
+        /// <param name="stream">the Stream to read from</param>
+        /// <param name="buffer">the buffer to read into</param>
+        /// <param name="offset">the offset in the buffer to read into</param>
+        /// <param name="count">the amount of bytes to read into the buffer</param>
+        /// <returns>returns the amount of read bytes</returns>
+        public static int ReadFixed(this Stream stream, byte[] buffer, int offset, int count)
+        {
+            int read = offset;
+            int received;
+            count = Math.Min(count, buffer.Length - offset);
+            do
+            {
+                received = stream.Read(buffer, read, count - read);
+                read += received;
+            }
+            while (read < count && received > 0);
+
+            return read;
+        }
+
+        /// <summary>
+        /// Reads a fixed amount of bytes from the stream into the buffer
+        /// </summary>
+        /// <param name="stream">the Stream to read from</param>
+        /// <param name="buffer">the buffer to read into</param>
+        /// <param name="offset">the offset in the buffer to read into</param>
+        /// <param name="count">the amount of bytes to read into the buffer</param>
+        /// <returns>returns the amount of read bytes</returns>
+        public static async Task<int> ReadFixedAsync(this Stream stream, byte[] buffer, int offset, int count)
+        {
+            int read = offset;
+            int received;
+            count = Math.Min(count, buffer.Length - offset);
+            do
+            {
+                received = await stream.ReadAsync(buffer, read, count - read);
+                read += received;
+            }
+            while (read < count && received > 0);
+
+            return read;
+        }
+    }
+}

--- a/S7.Net/TPKT.cs
+++ b/S7.Net/TPKT.cs
@@ -32,21 +32,16 @@ namespace S7.Net
         public static TPKT Read(Stream stream)
         {
             var buf = new byte[4];
-            int len = stream.Read(buf, 0, 4);
-            if (len < 4) throw new TPKTInvalidException("TPKT header incomplete / invalid");
+            int len = stream.ReadFixed(buf, 0, 4);
+            if (len < 4) throw new TPKTInvalidException("TPKT is incomplete / invalid");
             var version = buf[0];
             var reserved1 = buf[1];
             var length = buf[2] * 256 + buf[3]; //BigEndian
 
-            if (length == 0)
-            {
-                throw new TPKTInvalidException("TPKT payload length is zero");
-            }
-
             var data = new byte[length - 4];
-            len = stream.Read(data, 0, length - 4);
-            if (len < length - 4)
-                throw new TPKTInvalidException("TPKT payload incomplete / invalid");
+            len = stream.ReadFixed(data, 0, data.Length);
+            if (len < data.Length)
+                throw new TPKTInvalidException("TPKT is incomplete / invalid");
 
             return new TPKT
             (
@@ -65,20 +60,16 @@ namespace S7.Net
         public static async Task<TPKT> ReadAsync(Stream stream)
         {
             var buf = new byte[4];
-            int len = await stream.ReadAsync(buf, 0, 4);
-            if (len < 4) throw new TPKTInvalidException("TPKT header incomplete / invalid");
+            int len = await stream.ReadFixedAsync(buf, 0, 4);
+            if (len < 4) throw new TPKTInvalidException("TPKT is incomplete / invalid");
+
             var version = buf[0];
             var reserved1 = buf[1];
             var length = buf[2] * 256 + buf[3]; //BigEndian
 
-            if (length == 0)
-            {
-                throw new TPKTInvalidException("TPKT payload length is zero");
-            }
-
             var data = new byte[length - 4];
-            len = await stream.ReadAsync(data, 0, length - 4);
-            if (len < length - 4)
+            len = await stream.ReadFixedAsync(data, 0, data.Length);
+            if (len < data.Length)
                 throw new TPKTInvalidException("TPKT payload incomplete / invalid");
 
             return new TPKT

--- a/S7.Net/TPKT.cs
+++ b/S7.Net/TPKT.cs
@@ -33,7 +33,7 @@ namespace S7.Net
         {
             var buf = new byte[4];
             int len = stream.ReadExact(buf, 0, 4);
-            if (len < 4) throw new TPKTInvalidException("TPKT is incomplete / invalid");
+            if (len < 4) throw new TPKTInvalidException($"TPKT header is incomplete / invalid. Received Bytes: {len} expected: {buf.Length}");
             var version = buf[0];
             var reserved1 = buf[1];
             var length = buf[2] * 256 + buf[3]; //BigEndian
@@ -41,7 +41,7 @@ namespace S7.Net
             var data = new byte[length - 4];
             len = stream.ReadExact(data, 0, data.Length);
             if (len < data.Length)
-                throw new TPKTInvalidException("TPKT is incomplete / invalid");
+                throw new TPKTInvalidException($"TPKT payload is incomplete / invalid. Received Bytes: {len} expected: {data.Length}");
 
             return new TPKT
             (

--- a/S7.Net/TPKT.cs
+++ b/S7.Net/TPKT.cs
@@ -32,14 +32,14 @@ namespace S7.Net
         public static TPKT Read(Stream stream)
         {
             var buf = new byte[4];
-            int len = stream.ReadFixed(buf, 0, 4);
+            int len = stream.ReadExact(buf, 0, 4);
             if (len < 4) throw new TPKTInvalidException("TPKT is incomplete / invalid");
             var version = buf[0];
             var reserved1 = buf[1];
             var length = buf[2] * 256 + buf[3]; //BigEndian
 
             var data = new byte[length - 4];
-            len = stream.ReadFixed(data, 0, data.Length);
+            len = stream.ReadExact(data, 0, data.Length);
             if (len < data.Length)
                 throw new TPKTInvalidException("TPKT is incomplete / invalid");
 
@@ -60,7 +60,7 @@ namespace S7.Net
         public static async Task<TPKT> ReadAsync(Stream stream)
         {
             var buf = new byte[4];
-            int len = await stream.ReadFixedAsync(buf, 0, 4);
+            int len = await stream.ReadExactAsync(buf, 0, 4);
             if (len < 4) throw new TPKTInvalidException("TPKT is incomplete / invalid");
 
             var version = buf[0];
@@ -68,7 +68,7 @@ namespace S7.Net
             var length = buf[2] * 256 + buf[3]; //BigEndian
 
             var data = new byte[length - 4];
-            len = await stream.ReadFixedAsync(data, 0, data.Length);
+            len = await stream.ReadExactAsync(data, 0, data.Length);
             if (len < data.Length)
                 throw new TPKTInvalidException("TPKT payload incomplete / invalid");
 


### PR DESCRIPTION
Alternative resolution for #289

based on the initial work of @jakob-lenderman with some small adjustments. It tries to resolve the initial problem of terminating Stream.Reads too early if the call returns less bytes than requested.

Adds a Unit-Test with a Test Stream class instead of MemoryStream to verify that this should be working.
