### PR TITLE
Add nullable support throughout the whole library.

### DIFF
--- a/S7.Net.UnitTest/S7NetTestsAsync.cs
+++ b/S7.Net.UnitTest/S7NetTestsAsync.cs
@@ -591,15 +591,13 @@ namespace S7.Net.UnitTest
 
 
         [TestMethod]
-        [ExpectedException(typeof(NullReferenceException))]
         public async Task Test_Async_ReadBytesReturnsNullIfPlcIsNotConnected()
         {
             using (var notConnectedPlc = new Plc(CpuType.S7300, "255.255.255.255", 0, 0))
             {
                 Assert.IsFalse(notConnectedPlc.IsConnected);
                 TestClass tc = new TestClass();
-                var res = await notConnectedPlc.ReadClassAsync(tc, DB2);
-                Assert.Fail();
+                await Assert.ThrowsExceptionAsync<PlcException>(async () => await notConnectedPlc.ReadClassAsync(tc, DB2));
             }
         }
 
@@ -637,13 +635,12 @@ namespace S7.Net.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(NullReferenceException))]
         public async Task Test_Async_ReadClassWithGenericReturnsNullIfPlcIsNotConnected()
         {
             using (var notConnectedPlc = new Plc(CpuType.S7300, "255.255.255.255", 0, 0))
             {
                 Assert.IsFalse(notConnectedPlc.IsConnected, "Before executing this test, the plc must be connected. Check constructor.");
-                TestClass tc = await notConnectedPlc.ReadClassAsync<TestClass>(DB2);
+                await Assert.ThrowsExceptionAsync<PlcException>(async () => await notConnectedPlc.ReadClassAsync<TestClass>(DB2));
             }
         }
 
@@ -678,13 +675,12 @@ namespace S7.Net.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(NullReferenceException))]
         public async Task Test_Async_ReadClassWithGenericAndClassFactoryThrowsExceptionPlcIsNotConnected()
         {
             using (var notConnectedPlc = new Plc(CpuType.S7300, "255.255.255.255", 0, 0))
             {
                 Assert.IsFalse(notConnectedPlc.IsConnected);
-                TestClass tc = await notConnectedPlc.ReadClassAsync(() => new TestClass(), DB2);
+                await Assert.ThrowsExceptionAsync<PlcException>(async () => await notConnectedPlc.ReadClassAsync(() => new TestClass(), DB2));
             }
         }
 
@@ -711,13 +707,12 @@ namespace S7.Net.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(NullReferenceException))]
         public async Task Test_Async_ReadStructThrowsExceptionPlcIsNotConnected()
         {
             using (var notConnectedPlc = new Plc(CpuType.S7300, "255.255.255.255", 0, 0))
             {
                 Assert.IsFalse(notConnectedPlc.IsConnected);
-                object tsObj = await notConnectedPlc.ReadStructAsync(typeof(TestStruct), DB2);
+                await Assert.ThrowsExceptionAsync<PlcException>(async () => await notConnectedPlc.ReadStructAsync(typeof(TestStruct), DB2));
             }
         }
 
@@ -754,13 +749,12 @@ namespace S7.Net.UnitTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(NullReferenceException))]
         public async Task Test_Async_ReadStructWithGenericThrowsExceptionIfPlcIsNotConnected()
         {
             using (var notConnectedPlc = new Plc(CpuType.S7300, "255.255.255.255", 0, 0))
             {
                 Assert.IsFalse(notConnectedPlc.IsConnected);
-                object tsObj = await notConnectedPlc.ReadStructAsync<TestStruct>(DB2);
+                await Assert.ThrowsExceptionAsync<PlcException>(async () => await notConnectedPlc.ReadStructAsync<TestStruct>(DB2));
             }
         }
 

--- a/S7.Net/COTP.cs
+++ b/S7.Net/COTP.cs
@@ -54,8 +54,11 @@ namespace S7.Net
             public static TPDU Read(Stream stream)
             {
                 var tpkt = TPKT.Read(stream);
-                if (tpkt.Length > 0) return new TPDU(tpkt);
-                return null;
+                if (tpkt.Length == 0)
+                {
+                    throw new TPDUInvalidException("No protocol data received");
+                }
+                return new TPDU(tpkt);
             }
 
             /// <summary>
@@ -67,8 +70,11 @@ namespace S7.Net
             public static async Task<TPDU> ReadAsync(Stream stream)
             {
                 var tpkt = await TPKT.ReadAsync(stream);
-                if (tpkt.Length > 0) return new TPDU(tpkt);
-                return null;
+                if (tpkt.Length == 0)
+                {
+                    throw new TPDUInvalidException("No protocol data received");
+                }
+                return new TPDU(tpkt);
             }
 
             public override string ToString()
@@ -98,7 +104,6 @@ namespace S7.Net
             public static byte[] Read(Stream stream)
             {
                 var segment = TPDU.Read(stream);
-                if (segment == null) return null;
 
                 var buffer = new byte[segment.Data.Length];
                 var output = new MemoryStream(buffer);
@@ -125,7 +130,6 @@ namespace S7.Net
             public static async Task<byte[]> ReadAsync(Stream stream)
             {                
                 var segment = await TPDU.ReadAsync(stream);
-                if (segment == null) return null;
 
                 var buffer = new byte[segment.Data.Length];
                 var output = new MemoryStream(buffer);

--- a/S7.Net/PLC.cs
+++ b/S7.Net/PLC.cs
@@ -15,8 +15,8 @@ namespace S7.Net
         private const int CONNECTION_TIMED_OUT_ERROR_CODE = 10060;
         
         //TCP connection to device
-        private TcpClient tcpClient;
-        private NetworkStream stream;
+        private TcpClient? tcpClient;
+        private NetworkStream? _stream;
 
         private int readTimeout = System.Threading.Timeout.Infinite;
         private int writeTimeout = System.Threading.Timeout.Infinite;
@@ -24,27 +24,27 @@ namespace S7.Net
         /// <summary>
         /// IP address of the PLC
         /// </summary>
-        public string IP { get; private set; }
+        public string IP { get; }
 
         /// <summary>
         /// PORT Number of the PLC, default is 102
         /// </summary>
-        public int Port { get; private set; }
+        public int Port { get; }
 
         /// <summary>
         /// CPU type of the PLC
         /// </summary>
-        public CpuType CPU { get; private set; }
+        public CpuType CPU { get; }
 
         /// <summary>
         /// Rack of the PLC
         /// </summary>
-        public Int16 Rack { get; private set; }
+        public Int16 Rack { get; }
 
         /// <summary>
         /// Slot of the CPU of the PLC
         /// </summary>
-        public Int16 Slot { get; private set; }
+        public Int16 Slot { get; }
 
         /// <summary>
         /// Max PDU size this cpu supports

--- a/S7.Net/PLCExceptions.cs
+++ b/S7.Net/PLCExceptions.cs
@@ -89,4 +89,25 @@ namespace S7.Net
         }
         #endif
     }
+
+    internal class TPDUInvalidException : Exception
+    {
+        public TPDUInvalidException() : base()
+        {
+        }
+
+        public TPDUInvalidException(string message) : base(message)
+        {
+        }
+
+        public TPDUInvalidException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+#if NET_FULL
+        protected TPDUInvalidException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+#endif
+    }
 }

--- a/S7.Net/PLCHelpers.cs
+++ b/S7.Net/PLCHelpers.cs
@@ -82,7 +82,7 @@ namespace S7.Net
         /// <param name="varCount"></param>
         /// <param name="bitAdr"></param>
         /// <returns></returns>
-        private object ParseBytes(VarType varType, byte[] bytes, int varCount, byte bitAdr = 0)
+        private object? ParseBytes(VarType varType, byte[] bytes, int varCount, byte bitAdr = 0)
         {
             if (bytes == null || bytes.Length == 0)
                 return null;

--- a/S7.Net/Protocol/S7WriteMultiple.cs
+++ b/S7.Net/Protocol/S7WriteMultiple.cs
@@ -91,7 +91,7 @@ namespace S7.Net.Protocol
 
             IList<byte> itemResults = new ArraySegment<byte>(message, 14, dataItems.Length);
 
-            List<Exception> errors = null;
+            List<Exception>? errors = null;
 
             for (int i = 0; i < dataItems.Length; i++)
             {

--- a/S7.Net/S7.Net.csproj
+++ b/S7.Net/S7.Net.csproj
@@ -15,6 +15,8 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>PLC Siemens Communication S7</PackageTags>
     <Copyright>Derek Heiser 2015</Copyright>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>Enable</Nullable>
     <DebugType>portable</DebugType>
     <EmbedAllSources>true</EmbedAllSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/S7.Net/Types/Class.cs
+++ b/S7.Net/Types/Class.cs
@@ -106,9 +106,9 @@ namespace S7.Net.Types
             return numBytes;
         }
 
-        private static object GetPropertyValue(Type propertyType, byte[] bytes, ref double numBytes)
+        private static object? GetPropertyValue(Type propertyType, byte[] bytes, ref double numBytes)
         {
-            object value = null;
+            object? value = null;
 
             switch (propertyType.Name)
             {
@@ -245,7 +245,7 @@ namespace S7.Net.Types
         {
             int bytePos = 0;
             int bitPos = 0;
-            byte[] bytes2 = null;
+            byte[]? bytes2 = null;
 
             switch (propertyValue.GetType().Name)
             {

--- a/S7.Net/Types/DataItem.cs
+++ b/S7.Net/Types/DataItem.cs
@@ -40,7 +40,7 @@ namespace S7.Net.Types
         /// <summary>
         /// Contains the value of the memory area after the read has been executed
         /// </summary>
-        public object Value { get; set; }
+        public object? Value { get; set; }
 
         /// <summary>
         /// Create an instance of DataItem
@@ -83,7 +83,14 @@ namespace S7.Net.Types
             var dataItem = FromAddress(address);
             dataItem.Value = value;
 
-            if (typeof(T).IsArray) dataItem.Count = ((Array) dataItem.Value).Length;
+            if (typeof(T).IsArray)
+            {
+                var array = ((Array?)dataItem.Value);
+                if ( array != null)
+                {
+                    dataItem.Count = array.Length;
+                }
+            }
 
             return dataItem;
         }

--- a/S7.Net/Types/Struct.cs
+++ b/S7.Net/Types/Struct.cs
@@ -70,7 +70,7 @@ namespace S7.Net.Types
         /// <param name="structType">The struct type</param>
         /// <param name="bytes">The array of bytes</param>
         /// <returns>The object depending on the struct type or null if fails(array-length != struct-length</returns>
-        public static object FromBytes(Type structType, byte[] bytes)
+        public static object? FromBytes(Type structType, byte[] bytes)
         {
             if (bytes == null)
                 return null;
@@ -198,7 +198,7 @@ namespace S7.Net.Types
 
             int size = Struct.GetStructSize(type);
             byte[] bytes = new byte[size];
-            byte[] bytes2 = null;
+            byte[]? bytes2 = null;
 
             int bytePos = 0;
             int bitPos = 0;


### PR DESCRIPTION
This requires reference types that can be null to be annotated by a ? operator, similar to value types.

This gives the advantage that the compiler can warn against any nullreference exceptions, of which this commits elimits a few.

To make the underlying protocol implementation not any more complicated and to eliminate existing problems, and to give more precise error reporting, I replaced some return null statements with explicit Exceptions. This lead to the assumption that those core protocol functions always return non-null objects if they do not throw, making the PLC code simpler.

Adjust some NotConnected tests to look for explicit PlcException instead of NullReferenceException.