### PR TITLE
For ReadStruct/WriteStruct, add ordering of fields by declaration order. 

### DIFF
--- a/S7.Net.UnitTest/Helpers/TestLongStruct.cs
+++ b/S7.Net.UnitTest/Helpers/TestLongStruct.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace S7.UnitTest.Helpers
@@ -8,6 +9,7 @@ namespace S7.UnitTest.Helpers
     /// <summary>
     /// This is a struct that contains more than 200 bytes and that needs 2 plc requests to complete a read/write cycle
     /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
     struct TestLongStruct
     {
         // these variables are not used, but are needed to match the size of the DB

--- a/S7.Net.UnitTest/Helpers/TestStruct.cs
+++ b/S7.Net.UnitTest/Helpers/TestStruct.cs
@@ -1,6 +1,8 @@
-﻿
+﻿using System.Runtime.InteropServices;
+
 namespace S7.Net.UnitTest.Helpers
 {
+    [StructLayout(LayoutKind.Sequential)]
     public struct TestStruct
     {
         /// <summary>
@@ -50,6 +52,6 @@ namespace S7.Net.UnitTest.Helpers
         /// <summary>
         /// DB1.DBD16
         /// </summary>
-        public ushort DWordVariable;
+        public uint DWordVariable;
     }
 }

--- a/S7.Net.UnitTest/Helpers/TestStruct.cs
+++ b/S7.Net.UnitTest/Helpers/TestStruct.cs
@@ -53,5 +53,8 @@ namespace S7.Net.UnitTest.Helpers
         /// DB1.DBD16
         /// </summary>
         public uint DWordVariable;
+
+        public byte ByteVariable;
+        public ushort WordVariable;
     }
 }

--- a/S7.Net.UnitTest/S7NetTestsSync.cs
+++ b/S7.Net.UnitTest/S7NetTestsSync.cs
@@ -241,8 +241,8 @@ namespace S7.Net.UnitTest
             tc.BitVariable10 = true;
             tc.DIntVariable = -100000;
             tc.IntVariable = -15000;
-            tc.RealVariableDouble = -154.789;
-            tc.RealVariableFloat = -154.789f;
+            tc.LRealVariable = -154.789;
+            tc.RealVariable = -154.789f;
             tc.DWordVariable = 850;
             plc.WriteStruct(tc, DB2);
 
@@ -258,7 +258,7 @@ namespace S7.Net.UnitTest
 
 
             var dWordBytes = new byte[4];
-            Array.Copy(binaryData, 16, dWordBytes, 0, 4);
+            Array.Copy(binaryData, 20, dWordBytes, 0, 4);
             var dWordValue = Types.DWord.FromByteArray(dWordBytes);
             Assert.AreEqual(tc.DWordVariable, dWordValue);
         }

--- a/S7.Net.UnitTest/S7NetTestsSync.cs
+++ b/S7.Net.UnitTest/S7NetTestsSync.cs
@@ -211,6 +211,8 @@ namespace S7.Net.UnitTest
             tc.LRealVariable = -154.789;
             tc.RealVariable = -154.789f;
             tc.DWordVariable = 850;
+            tc.ByteVariable = 231;
+            tc.WordVariable = 21923;
             plc.WriteStruct(tc, DB2);
             // Values that are read from a struct are stored in a new struct, returned by the funcion ReadStruct
             TestStruct tc2 = (TestStruct)plc.ReadStruct(typeof(TestStruct), DB2);
@@ -221,6 +223,8 @@ namespace S7.Net.UnitTest
             Assert.AreEqual(tc.LRealVariable, tc2.LRealVariable);
             Assert.AreEqual(tc.RealVariable, tc2.RealVariable);
             Assert.AreEqual(tc.DWordVariable, tc2.DWordVariable);
+            Assert.AreEqual(tc.ByteVariable, tc2.ByteVariable);
+            Assert.AreEqual(tc.WordVariable, tc2.WordVariable);
         }
 
         /// <summary>

--- a/S7.Net/PlcAsynchronous.cs
+++ b/S7.Net/PlcAsynchronous.cs
@@ -117,10 +117,12 @@ namespace S7.Net
 
         /// <summary>
         /// Reads all the bytes needed to fill a struct in C#, starting from a certain address, and return an object that can be casted to the struct.
+        /// Requires the struct/class to have [StructLayout(LayoutKind.Sequential)] attribute
         /// </summary>
         /// <param name="structType">Type of the struct to be readed (es.: TypeOf(MyStruct)).</param>
         /// <param name="db">Address of the DB.</param>
         /// <param name="startByteAdr">Start byte address. If you want to read DB1.DBW200, this is 200.</param>
+        /// <exception cref="ArgumentException">When [StructLayout(LayoutKind.Sequential)] attribute is not set for the structType</exception>
         /// <returns>Returns a struct that must be cast.</returns>
         public async Task<object?> ReadStructAsync(Type structType, int db, int startByteAdr = 0)
         {

--- a/S7.Net/PlcSynchronous.cs
+++ b/S7.Net/PlcSynchronous.cs
@@ -133,10 +133,12 @@ namespace S7.Net
 
         /// <summary>
         /// Reads all the bytes needed to fill a struct in C#, starting from a certain address, and return an object that can be casted to the struct.
+        /// Requires the struct to have [StructLayout(LayoutKind.Sequential)] attribute
         /// </summary>
         /// <param name="structType">Type of the struct to be readed (es.: TypeOf(MyStruct)).</param>
         /// <param name="db">Address of the DB.</param>
         /// <param name="startByteAdr">Start byte address. If you want to read DB1.DBW200, this is 200.</param>
+        /// <exception cref="ArgumentException">When [StructLayout(LayoutKind.Sequential)] attribute is not set for the struct type</exception>
         /// <returns>Returns a struct that must be cast. If no data has been read, null will be returned</returns>
         public object? ReadStruct(Type structType, int db, int startByteAdr = 0)
         {
@@ -150,10 +152,12 @@ namespace S7.Net
 
         /// <summary>
         /// Reads all the bytes needed to fill a struct in C#, starting from a certain address, and returns the struct or null if nothing was read.
+        /// Requires the struct to have [StructLayout(LayoutKind.Sequential)] attribute
         /// </summary>
         /// <typeparam name="T">The struct type</typeparam>
         /// <param name="db">Address of the DB.</param>
         /// <param name="startByteAdr">Start byte address. If you want to read DB1.DBW200, this is 200.</param>
+        /// <exception cref="ArgumentException">When [StructLayout(LayoutKind.Sequential)] attribute is not set for the struct type</exception>
         /// <returns>Returns a nullable struct. If nothing was read null will be returned.</returns>
         public T? ReadStruct<T>(int db, int startByteAdr = 0) where T : struct
         {
@@ -323,10 +327,12 @@ namespace S7.Net
 
         /// <summary>
         /// Writes a C# struct to a DB in the PLC
+        /// Requires the struct to have [StructLayout(LayoutKind.Sequential)] attribute
         /// </summary>
         /// <param name="structValue">The struct to be written</param>
         /// <param name="db">Db address</param>
         /// <param name="startByteAdr">Start bytes on the PLC</param>
+        /// <exception cref="ArgumentException">When [StructLayout(LayoutKind.Sequential)] attribute is not set for the struct type</exception>
         public void WriteStruct(object structValue, int db, int startByteAdr = 0)
         {
             WriteStructAsync(structValue, db, startByteAdr).GetAwaiter().GetResult();

--- a/S7.Net/Types/Class.cs
+++ b/S7.Net/Types/Class.cs
@@ -20,7 +20,7 @@ namespace S7.Net.Types
                     BindingFlags.SetProperty |
                     BindingFlags.Public |
                     BindingFlags.Instance)
-                .Where(p => p.GetSetMethod() != null);
+                .Where(p => p.GetSetMethod() != null).OrderBy(p => p.MetadataToken);
 #endif
 
         }


### PR DESCRIPTION
This should fix #135 , but it does require users to add [StructLayout(LayoutKind.Sequential)] attribute to their classes.

This implementation throws if that is not the case, so will break existing code. I am not sure how lenient the library intends to be here or not.

Also fix a parsing error for DWord in ReadStruct, which mixed up endianes.