### PR TITLE
Remove EmbedAllSources from S7.Net

### DIFF
--- a/S7.Net/S7.Net.csproj
+++ b/S7.Net/S7.Net.csproj
@@ -18,7 +18,6 @@
     <LangVersion>8.0</LangVersion>
     <Nullable>Enable</Nullable>
     <DebugType>portable</DebugType>
-    <EmbedAllSources>true</EmbedAllSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>


### PR DESCRIPTION
Sources are already provided via SourceLink, no need to embed them as
well.