### PR TITLE
Fix OpenAsync function to rethrow exception during connection establish.

### DIFF
--- a/S7.Net/PlcAsynchronous.cs
+++ b/S7.Net/PlcAsynchronous.cs
@@ -35,6 +35,7 @@ namespace S7.Net
             catch(Exception)
             {
                 stream.Dispose();
+                throw;
             }
         }
 


### PR DESCRIPTION
This bug was introduced in 106e9912