### PR TITLE
Close connection on IOExceptions.

### DIFF
--- a/S7.Net/PLC.cs
+++ b/S7.Net/PLC.cs
@@ -162,6 +162,7 @@ namespace S7.Net
             if (tcpClient != null)
             {
                 if (tcpClient.Connected) tcpClient.Close();
+                tcpClient = null; // Can not reuse TcpClient once connection gets closed.
             }
         }
 


### PR DESCRIPTION
Let our protocol exceptions derive from IOException so their errors are handled nicely alongside other IOExceptions.

The idea behind this is that if we receive a response which does not conform to the underlying protocol specification (with all the TCP checks in place!), we are in a weird/corrupt state and it is better to just close the connection.