### PR TITLE
Fix problems with S7 string types (S7String and S7WString) and calculated byte length

### DIFF
--- a/S7.Net.UnitTest/TypeTests/S7StringTests.cs
+++ b/S7.Net.UnitTest/TypeTests/S7StringTests.cs
@@ -117,12 +117,23 @@ namespace S7.Net.UnitTest.TypeTests
             AssertToByteArrayAndBackEquals("Abc", 4, 4, 3, (byte) 'A', (byte) 'b', (byte) 'c', 0);
         }
 
+        [TestMethod]
+        public void OddS7StringByteLength()
+        {
+            AssertVarTypeToByteLength(VarType.S7String, 1, 4);
+        }
+
+        [TestMethod]
+        public void EvenS7StringByteLength()
+        {
+            AssertVarTypeToByteLength(VarType.S7String, 2, 4);
+        }
+
         private static void AssertFromByteArrayEquals(string expected, params byte[] bytes)
         {
             var convertedString = S7String.FromByteArray(bytes);
             Assert.AreEqual(expected, convertedString);
         }
-
 
         private static void AssertToByteArrayAndBackEquals(string value, int reservedLength, params byte[] expected)
         {
@@ -130,6 +141,12 @@ namespace S7.Net.UnitTest.TypeTests
             CollectionAssert.AreEqual(expected, convertedData);
             var convertedBack = S7String.FromByteArray(convertedData);
             Assert.AreEqual(value, convertedBack);
+        }
+
+        private void AssertVarTypeToByteLength(VarType varType, int count, int expectedByteLength)
+        {
+            var byteLength = Plc.VarTypeToByteLength(varType, count);
+            Assert.AreEqual(expectedByteLength, byteLength);
         }
     }
 }

--- a/S7.Net.UnitTest/TypeTests/S7WStringTests.cs
+++ b/S7.Net.UnitTest/TypeTests/S7WStringTests.cs
@@ -122,6 +122,17 @@ namespace S7.Net.UnitTest.TypeTests
             Assert.AreEqual(expected, convertedString);
         }
 
+        [TestMethod]
+        public void OddS7WStringByteLength()
+        {
+            AssertVarTypeToByteLength(VarType.S7WString, 1, 6);
+        }
+
+        [TestMethod]
+        public void EvenS7WStringByteLength()
+        {
+            AssertVarTypeToByteLength(VarType.S7WString, 2, 8);
+        }
 
         private static void AssertToByteArrayAndBackEquals(string value, int reservedLength, params byte[] expected)
         {
@@ -129,6 +140,12 @@ namespace S7.Net.UnitTest.TypeTests
             CollectionAssert.AreEqual(expected, convertedData);
             var convertedBack = S7WString.FromByteArray(convertedData);
             Assert.AreEqual(value, convertedBack);
+        }
+
+        private void AssertVarTypeToByteLength(VarType varType, int count, int expectedByteLength)
+        {
+            var byteLength = Plc.VarTypeToByteLength(varType, count);
+            Assert.AreEqual(expectedByteLength, byteLength);
         }
     }
 }

--- a/S7.Net/PLCHelpers.cs
+++ b/S7.Net/PLCHelpers.cs
@@ -191,6 +191,8 @@ namespace S7.Net
                     return varCount;
                 case VarType.S7String:
                     return varCount + 2;
+                case VarType.S7WString:
+                    return (varCount * 2) + 4;
                 case VarType.Word:
                 case VarType.Timer:
                 case VarType.Int:

--- a/S7.Net/PLCHelpers.cs
+++ b/S7.Net/PLCHelpers.cs
@@ -190,7 +190,7 @@ namespace S7.Net
                 case VarType.String:
                     return varCount;
                 case VarType.S7String:
-                    return varCount + 2;
+                    return ((varCount + 2) & 1) == 1 ? (varCount + 3) : (varCount + 2);
                 case VarType.S7WString:
                     return (varCount * 2) + 4;
                 case VarType.Word:


### PR DESCRIPTION
This pull requests fixes #376.

The S7WString fix it is a simple one with no danger of breaking anything. The S7String fix can be more dangerous, although it passes all the tests.

I also added two new test methods to both test cases related to these fixes.