### PR TITLE
Flowed cancellation token to TcpClient.ConnectAsync in .NET 5.0 target

### DIFF
--- a/S7.Net/PlcAsynchronous.cs
+++ b/S7.Net/PlcAsynchronous.cs
@@ -25,7 +25,7 @@ namespace S7.Net
         /// <returns>A task that represents the asynchronous open operation.</returns>
         public async Task OpenAsync(CancellationToken cancellationToken = default)
         {
-            var stream = await ConnectAsync().ConfigureAwait(false);
+            var stream = await ConnectAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 await queue.Enqueue(async () =>
@@ -44,11 +44,16 @@ namespace S7.Net
             }
         }
 
-        private async Task<NetworkStream> ConnectAsync()
+        private async Task<NetworkStream> ConnectAsync(CancellationToken cancellationToken)
         {
             tcpClient = new TcpClient();
             ConfigureConnection();
+
+#if NET5_0_OR_GREATER
+            await tcpClient.ConnectAsync(IP, Port, cancellationToken).ConfigureAwait(false);
+#else
             await tcpClient.ConnectAsync(IP, Port).ConfigureAwait(false);
+#endif
             return tcpClient.GetStream();
         }
 

--- a/S7.Net/S7.Net.csproj
+++ b/S7.Net/S7.Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0;netstandard1.3;net5.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Properties\S7.Net.snk</AssemblyOriginatorKeyFile>
     <InternalsVisibleTo>S7.Net.UnitTest</InternalsVisibleTo>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration: Release
 install:
   - choco install gitversion.portable -y


### PR DESCRIPTION
Fixes https://github.com/S7NetPlus/s7netplus/issues/422

---

I wanted to add a test similar to https://github.com/S7NetPlus/s7netplus/blob/b475aee2e768f709e6b8f01084b176e53d43cd8c/S7.Net.UnitTest/S7NetTestsAsync.cs#L39-L46 but then saw that due https://github.com/S7NetPlus/s7netplus/blob/b475aee2e768f709e6b8f01084b176e53d43cd8c/S7.Net.UnitTest/S7NetTestsSync.cs#L63-L68 the connection will always be established in the setup, so this test (and the one I'd like to add) are actually nops.

Personally I don't have a problem when there's no test, as the code just passes the cancellation token to the framework provided method, so there's not much to test anyway.