### PR TITLE
Allow changing the default Encoding used in S7String

### DIFF
--- a/S7.Net/Types/S7String.cs
+++ b/S7.Net/Types/S7String.cs
@@ -9,10 +9,17 @@ namespace S7.Net.Types
     /// </summary>
     public static class S7String
     {
+        private static Encoding stringEncoding;
+
         /// <summary>
         /// The Encoding used when serializing and deserializing S7String (Encoding.ASCII by default)
         /// </summary>
-        public static Encoding StringEncoding { get; set; }
+        /// <exception cref="ArgumentNullException">StringEncoding must not be null</exception>
+        public static Encoding StringEncoding
+        {
+            get => stringEncoding ??= Encoding.ASCII;
+            set => stringEncoding = value ?? throw new ArgumentNullException(nameof(StringEncoding));
+        }
 
         /// <summary>
         /// Converts S7 bytes to a string
@@ -35,7 +42,6 @@ namespace S7.Net.Types
 
             try
             {
-                if (StringEncoding == null) StringEncoding = Encoding.ASCII;
                 return StringEncoding.GetString(bytes, 2, length);
             }
             catch (Exception e)
@@ -61,7 +67,6 @@ namespace S7.Net.Types
 
             if (reservedLength > 254) throw new ArgumentException($"The maximum string length supported is 254.");
 
-            if (StringEncoding == null) StringEncoding = Encoding.ASCII;
             var bytes = StringEncoding.GetBytes(value);
             if (bytes.Length > reservedLength) throw new ArgumentException($"The provided string length ({bytes.Length} is larger than the specified reserved length ({reservedLength}).");
 
@@ -70,14 +75,6 @@ namespace S7.Net.Types
             buffer[0] = (byte)reservedLength;
             buffer[1] = (byte)bytes.Length;
             return buffer;
-        }
-
-        /// <summary>
-        /// Initializes default static properties
-        /// </summary>
-        static S7String()
-        {
-            StringEncoding = Encoding.ASCII;
         }
     }
 }

--- a/S7.Net/Types/S7String.cs
+++ b/S7.Net/Types/S7String.cs
@@ -10,6 +10,11 @@ namespace S7.Net.Types
     public static class S7String
     {
         /// <summary>
+        /// The Encoding used when serializing and deserializing S7String (Encoding.ASCII by default)
+        /// </summary>
+        public static Encoding StringEncoding { get; set; }
+
+        /// <summary>
         /// Converts S7 bytes to a string
         /// </summary>
         /// <param name="bytes"></param>
@@ -30,7 +35,8 @@ namespace S7.Net.Types
 
             try
             {
-                return Encoding.ASCII.GetString(bytes, 2, length);
+                if (StringEncoding == null) StringEncoding = Encoding.ASCII;
+                return StringEncoding.GetString(bytes, 2, length);
             }
             catch (Exception e)
             {
@@ -38,7 +44,6 @@ namespace S7.Net.Types
                     $"Failed to parse {VarType.S7String} from data. Following fields were read: size: '{size}', actual length: '{length}', total number of bytes (including header): '{bytes.Length}'.",
                     e);
             }
-            
         }
 
         /// <summary>
@@ -56,7 +61,8 @@ namespace S7.Net.Types
 
             if (reservedLength > 254) throw new ArgumentException($"The maximum string length supported is 254.");
 
-            var bytes = Encoding.ASCII.GetBytes(value);
+            if (StringEncoding == null) StringEncoding = Encoding.ASCII;
+            var bytes = StringEncoding.GetBytes(value);
             if (bytes.Length > reservedLength) throw new ArgumentException($"The provided string length ({bytes.Length} is larger than the specified reserved length ({reservedLength}).");
 
             var buffer = new byte[2 + reservedLength];
@@ -64,6 +70,14 @@ namespace S7.Net.Types
             buffer[0] = (byte)reservedLength;
             buffer[1] = (byte)bytes.Length;
             return buffer;
+        }
+
+        /// <summary>
+        /// Initializes default static properties
+        /// </summary>
+        static S7String()
+        {
+            StringEncoding = Encoding.ASCII;
         }
     }
 }

--- a/S7.Net/Types/S7String.cs
+++ b/S7.Net/Types/S7String.cs
@@ -9,7 +9,7 @@ namespace S7.Net.Types
     /// </summary>
     public static class S7String
     {
-        private static Encoding stringEncoding;
+        private static Encoding stringEncoding = Encoding.ASCII;
 
         /// <summary>
         /// The Encoding used when serializing and deserializing S7String (Encoding.ASCII by default)
@@ -17,7 +17,7 @@ namespace S7.Net.Types
         /// <exception cref="ArgumentNullException">StringEncoding must not be null</exception>
         public static Encoding StringEncoding
         {
-            get => stringEncoding ??= Encoding.ASCII;
+            get => stringEncoding;
             set => stringEncoding = value ?? throw new ArgumentNullException(nameof(StringEncoding));
         }
 


### PR DESCRIPTION
The default Encoding.ASCII used in S7String to serialize and deserialize strings to/from byte array is not always valid in some situations where you want to use extended ASCII Code Pages, like the Windows 1252, or Iso-8859-1.

This simple PR allows user to change the Encoding system-wide, using an static property directly on the S7String class. I do not know if a central configuration already exists and this setting can be moved there. That would be nicer than this quick'n'dirty fix.