### PR TITLE
Fix bytes number approximation

### DIFF
--- a/S7.Net/Types/Struct.cs
+++ b/S7.Net/Types/Struct.cs
@@ -77,7 +77,7 @@ namespace S7.Net.Types
                         break;
                 }
             }
-            return (int)numBytes;
+            return (int)Math.Ceiling(numBytes);
         }
 
         /// <summary>


### PR DESCRIPTION
In case of a structure containing 9 bool type objects, the previous direct cast was rounding the resulting `numBytes` of `1.125` to `1` which is wrong because the last boolean is on the first bit of the second byte.