### PR TITLE
Use System.Memory for < .NET 5 and avoid (some) unnecessary allocations

### DIFF
--- a/S7.Net/Helper/MemoryStreamExtension.cs
+++ b/S7.Net/Helper/MemoryStreamExtension.cs
@@ -1,6 +1,10 @@
-﻿
+﻿using System;
+using System.Buffers;
+using System.IO;
+
 namespace S7.Net.Helper
 {
+#if !NET5_0_OR_GREATER
     internal static class MemoryStreamExtension
     {
         /// <summary>
@@ -10,9 +14,25 @@ namespace S7.Net.Helper
         /// </summary>
         /// <param name="stream"></param>
         /// <param name="value"></param>
-        public static void WriteByteArray(this System.IO.MemoryStream stream, byte[] value)
+        public static void Write(this MemoryStream stream, byte[] value)
         {
             stream.Write(value, 0, value.Length);
         }
+
+        /// <summary>
+        /// Helper function to write the whole content of the given byte span to a memory stream.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="value"></param>
+        public static void Write(this MemoryStream stream, ReadOnlySpan<byte> value)
+        {
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(value.Length);
+
+            value.CopyTo(buffer);
+            stream.Write(buffer, 0, value.Length);
+
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
     }
+#endif
 }

--- a/S7.Net/PLCHelpers.cs
+++ b/S7.Net/PLCHelpers.cs
@@ -1,7 +1,6 @@
 ﻿using S7.Net.Helper;
 using S7.Net.Protocol.S7;
 using S7.Net.Types;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using DateTime = S7.Net.Types.DateTime;
@@ -18,13 +17,13 @@ namespace S7.Net
         private static void BuildHeaderPackage(System.IO.MemoryStream stream, int amount = 1)
         {
             //header size = 19 bytes
-            stream.WriteByteArray(new byte[] { 0x03, 0x00 });
+            stream.Write(new byte[] { 0x03, 0x00 });
             //complete package size
-            stream.WriteByteArray(Types.Int.ToByteArray((short)(19 + (12 * amount))));
-            stream.WriteByteArray(new byte[] { 0x02, 0xf0, 0x80, 0x32, 0x01, 0x00, 0x00, 0x00, 0x00 });
+            stream.Write(Int.ToByteArray((short)(19 + (12 * amount))));
+            stream.Write(new byte[] { 0x02, 0xf0, 0x80, 0x32, 0x01, 0x00, 0x00, 0x00, 0x00 });
             //data part size
-            stream.WriteByteArray(Types.Word.ToByteArray((ushort)(2 + (amount * 12))));
-            stream.WriteByteArray(new byte[] { 0x00, 0x00, 0x04 });
+            stream.Write(Word.ToByteArray((ushort)(2 + (amount * 12))));
+            stream.Write(new byte[] { 0x00, 0x00, 0x04 });
             //amount of requests
             stream.WriteByte((byte)amount);
         }
@@ -41,7 +40,7 @@ namespace S7.Net
         private static void BuildReadDataRequestPackage(System.IO.MemoryStream stream, DataType dataType, int db, int startByteAdr, int count = 1)
         {
             //single data req = 12
-            stream.WriteByteArray(new byte[] { 0x12, 0x0a, 0x10 });
+            stream.Write(new byte[] { 0x12, 0x0a, 0x10 });
             switch (dataType)
             {
                 case DataType.Timer:
@@ -53,8 +52,8 @@ namespace S7.Net
                     break;
             }
 
-            stream.WriteByteArray(Word.ToByteArray((ushort)(count)));
-            stream.WriteByteArray(Word.ToByteArray((ushort)(db)));
+            stream.Write(Word.ToByteArray((ushort)(count)));
+            stream.Write(Word.ToByteArray((ushort)(db)));
             stream.WriteByte((byte)dataType);
             var overflow = (int)(startByteAdr * 8 / 0xffffU); // handles words with address bigger than 8191
             stream.WriteByte((byte)overflow);
@@ -62,10 +61,10 @@ namespace S7.Net
             {
                 case DataType.Timer:
                 case DataType.Counter:
-                    stream.WriteByteArray(Types.Word.ToByteArray((ushort)(startByteAdr)));
+                    stream.Write(Word.ToByteArray((ushort)(startByteAdr)));
                     break;
                 default:
-                    stream.WriteByteArray(Types.Word.ToByteArray((ushort)((startByteAdr) * 8)));
+                    stream.Write(Word.ToByteArray((ushort)((startByteAdr) * 8)));
                     break;
             }
         }

--- a/S7.Net/S7.Net.csproj
+++ b/S7.Net/S7.Net.csproj
@@ -26,6 +26,10 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>NET_FULL</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />


### PR DESCRIPTION
Unfortunately https://github.com/S7NetPlus/s7netplus/pull/482 got merged too fast, so I couldn't have a look and provide my feedback over there, thus here's a PR with my suggestions 😉

* For targets before .NET 5 the _System.Memory_ package is used, which provides Span, and Memory for these targets
  So the code can be simplified a bit by re-using parts of the code

* internal `MemoryStreamExtension.WriteBytes` renamed to `MemoryStreamExtension.Write` so that the usage as extension solely becomes `stream.Write`, so for .NET 5 (when built with VS 2022 as CI does ?!) the C# compiler can avoid some allocations by refering to assembly's static data segment, namely for patterns like `package.Write(new byte[] { 0x1, 0x2, ... }`. See [sharplab example](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA+ABATARgLABQGADAAQY4B0AkgPIDchhAxAHYCuANpwIbCcxSAEwCWAZz4CmRAMzkspAMKkA3oVIbSABygiAbjwAugiknIpSAIXYjOQgBIweQmFAAKPMAGseAcxgAFACyMAC20ACeAMqGsDyhpGKxTqEANKQirIak8RDsWaQAvKQ4AJTqmmoEmjWJyfGUAOq6xgGsMADupMARxgDaWAC6qqQy6WQAvqWM1bUaSXGhTS2B7V09/QCcwyqkWOlYKMTpOFgAHOkArMcl43ekN5PTFXMLKcsirWvdvTB9MjsHvcLFMZnN5vUls1PjBLL8AgENjBSrl8oZnrMNBNCBMgA) for this (the `PrivateImplementationDetails` refers to static data, no further allocation))