### PR TITLE
Added support for serializing TimeSpan

### DIFF
--- a/S7.Net.UnitTest/S7NetTestsAsync.cs
+++ b/S7.Net.UnitTest/S7NetTestsAsync.cs
@@ -1006,7 +1006,7 @@ namespace S7.Net.UnitTest
             var db = 2;
             randomEngine.NextBytes(data);
 
-            cancellationSource.CancelAfter(TimeSpan.FromMilliseconds(5));
+            cancellationSource.CancelAfter(System.TimeSpan.FromMilliseconds(5));
             try
             {
                 await plc.WriteBytesAsync(DataType.DataBlock, db, 0, data, cancellationToken);
@@ -1045,7 +1045,7 @@ namespace S7.Net.UnitTest
             var db = 2;
             randomEngine.NextBytes(data.Span);
 
-            cancellationSource.CancelAfter(TimeSpan.FromMilliseconds(5));
+            cancellationSource.CancelAfter(System.TimeSpan.FromMilliseconds(5));
             try
             {
                 await plc.WriteBytesAsync(DataType.DataBlock, db, 0, data, cancellationToken);

--- a/S7.Net.UnitTest/TypeTests/TimeSpanTests.cs
+++ b/S7.Net.UnitTest/TypeTests/TimeSpanTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace S7.Net.UnitTest.TypeTests
+{
+    public static class TimeSpanTests
+    {
+        private static readonly TimeSpan SampleTimeSpan = new TimeSpan(12, 0, 59, 37, 856);
+
+        private static readonly byte[] SampleByteArray = { 0x3E, 0x02, 0xE8, 0x00 };
+
+        private static readonly byte[] SpecMinByteArray = { 0x80, 0x00, 0x00, 0x00 };
+        
+        private static readonly byte[] SpecMaxByteArray = { 0x7F, 0xFF, 0xFF, 0xFF };
+
+        [TestClass]
+        public class FromByteArray
+        {
+            [TestMethod]
+            public void Sample()
+            {
+                AssertFromByteArrayEquals(SampleTimeSpan, SampleByteArray);
+            }
+
+            [TestMethod]
+            public void SpecMinimum()
+            {
+                AssertFromByteArrayEquals(Types.TimeSpan.SpecMinimumTimeSpan, SpecMinByteArray);
+            }
+
+            [TestMethod]
+            public void SpecMaximum()
+            {
+                AssertFromByteArrayEquals(Types.TimeSpan.SpecMaximumTimeSpan, SpecMaxByteArray);
+            }
+
+            private static void AssertFromByteArrayEquals(TimeSpan expected, params byte[] bytes)
+            {
+                Assert.AreEqual(expected, Types.TimeSpan.FromByteArray(bytes));
+            }
+        }
+
+        [TestClass]
+        public class ToByteArray
+        {
+            [TestMethod]
+            public void Sample()
+            {
+                AssertToByteArrayEquals(SampleTimeSpan, SampleByteArray);
+            }
+
+            [TestMethod]
+            public void SpecMinimum()
+            {
+                AssertToByteArrayEquals(Types.TimeSpan.SpecMinimumTimeSpan, SpecMinByteArray);
+            }
+
+            [TestMethod]
+            public void SpecMaximum()
+            {
+                AssertToByteArrayEquals(Types.TimeSpan.SpecMaximumTimeSpan, SpecMaxByteArray);
+            }
+
+            [TestMethod, ExpectedException(typeof(ArgumentOutOfRangeException))]
+            public void ThrowsOnTimeBeforeSpecMinimum()
+            {
+                Types.TimeSpan.ToByteArray(TimeSpan.FromDays(-25));
+            }
+
+            [TestMethod, ExpectedException(typeof(ArgumentOutOfRangeException))]
+            public void ThrowsOnTimeAfterSpecMaximum()
+            {
+                Types.TimeSpan.ToByteArray(new TimeSpan(30, 15, 15, 15, 15));
+            }
+
+            private static void AssertToByteArrayEquals(TimeSpan value, params byte[] expected)
+            {
+                CollectionAssert.AreEqual(expected, Types.TimeSpan.ToByteArray(value));
+            }
+        }
+    }
+}

--- a/S7.Net/Enums.cs
+++ b/S7.Net/Enums.cs
@@ -206,6 +206,11 @@
         /// <summary>
         /// DateTimeLong variable type
         /// </summary>
-        DateTimeLong
+        DateTimeLong,
+        
+        /// <summary>
+        /// S7 TIME variable type - serialized as S7 DInt and deserialized as C# TimeSpan 
+        /// </summary>
+        Time
     }
 }

--- a/S7.Net/PLCHelpers.cs
+++ b/S7.Net/PLCHelpers.cs
@@ -167,6 +167,15 @@ namespace S7.Net
                     {
                         return DateTimeLong.ToArray(bytes);
                     }
+                case VarType.Time:
+                    if (varCount == 1)
+                    {
+                        return TimeSpan.FromByteArray(bytes);
+                    }
+                    else
+                    {
+                        return TimeSpan.ToArray(bytes);
+                    }
                 default:
                     return null;
             }
@@ -200,6 +209,7 @@ namespace S7.Net
                 case VarType.DWord:
                 case VarType.DInt:
                 case VarType.Real:
+                case VarType.Time:
                     return varCount * 4;
                 case VarType.LReal:
                 case VarType.DateTime:

--- a/S7.Net/Types/Struct.cs
+++ b/S7.Net/Types/Struct.cs
@@ -45,6 +45,7 @@ namespace S7.Net.Types
                         break;
                     case "Int32":
                     case "UInt32":
+                    case "TimeSpan":
                         numBytes = Math.Ceiling(numBytes);
                         if ((numBytes / 2 - Math.Floor(numBytes / 2.0)) > 0)
                             numBytes++;
@@ -215,6 +216,21 @@ namespace S7.Net.Types
 
                         numBytes += sData.Length;
                         break;
+                    case "TimeSpan":
+                        numBytes = Math.Ceiling(numBytes);
+                        if ((numBytes / 2 - Math.Floor(numBytes / 2.0)) > 0)
+                            numBytes++;
+                        
+                        // get the value
+                        info.SetValue(structValue, TimeSpan.FromByteArray(new[] 
+                        {
+                            bytes[(int)numBytes + 0],
+                            bytes[(int)numBytes + 1],
+                            bytes[(int)numBytes + 2],
+                            bytes[(int)numBytes + 3]
+                        }));
+                        numBytes += 4;
+                        break;
                     default:
                         var buffer = new byte[GetStructSize(info.FieldType)];
                         if (buffer.Length == 0)
@@ -302,6 +318,9 @@ namespace S7.Net.Types
                             S7StringType.S7WString => S7WString.ToByteArray((string)info.GetValue(structValue), attribute.ReservedLength),
                             _ => throw new ArgumentException("Please use a valid string type for the S7StringAttribute")
                         };
+                        break;
+                    case "TimeSpan":
+                        bytes2 = TimeSpan.ToByteArray((System.TimeSpan)info.GetValue(structValue));
                         break;
                 }
                 if (bytes2 != null)

--- a/S7.Net/Types/TimeSpan.cs
+++ b/S7.Net/Types/TimeSpan.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 
 namespace S7.Net.Types
 {
+    /// <summary>
+    /// Contains the methods to convert between <see cref="T:System.TimeSpan"/> and S7 representation of TIME values.
+    /// </summary>
     public static class TimeSpan
     {
         /// <summary>
@@ -45,7 +48,6 @@ namespace S7.Net.Types
                 throw new ArgumentOutOfRangeException(nameof(bytes), bytes.Length,
                     $"Parsing an array of {nameof(System.TimeSpan)} requires a multiple of {singleTimeSpanLength} bytes of input data, input data is '{bytes.Length}' long.");
 
-            var cnt = bytes.Length / singleTimeSpanLength;
             var result = new System.TimeSpan[bytes.Length / singleTimeSpanLength];
 
             var milliseconds = DInt.ToArray(bytes);
@@ -56,13 +58,13 @@ namespace S7.Net.Types
         }
 
         /// <summary>
-        /// Converts a <see cref="T:System.DateTime"/> value to a byte array.
+        /// Converts a <see cref="T:System.TimeSpan"/> value to a byte array.
         /// </summary>
-        /// <param name="timeSpan">The DateTime value to convert.</param>
+        /// <param name="timeSpan">The TimeSpan value to convert.</param>
         /// <returns>A byte array containing the S7 date time representation of <paramref name="timeSpan"/>.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the value of
-        ///   <paramref name="timeSpan"/> is before <see cref="P:SpecMinimumDateTime"/>
-        ///   or after <see cref="P:SpecMaximumDateTime"/>.</exception>
+        ///   <paramref name="timeSpan"/> is before <see cref="P:SpecMinimumTimeSpan"/>
+        ///   or after <see cref="P:SpecMaximumTimeSpan"/>.</exception>
         public static byte[] ToByteArray(System.TimeSpan timeSpan)
         {
             if (timeSpan < SpecMinimumTimeSpan)
@@ -77,13 +79,13 @@ namespace S7.Net.Types
         }
 
         /// <summary>
-        /// Converts an array of <see cref="T:System.DateTime"/> values to a byte array.
+        /// Converts an array of <see cref="T:System.TimeSpan"/> values to a byte array.
         /// </summary>
-        /// <param name="timeSpans">The DateTime values to convert.</param>
-        /// <returns>A byte array containing the S7 date time representations of <paramref name="dateTime"/>.</returns>
+        /// <param name="timeSpans">The TimeSpan values to convert.</param>
+        /// <returns>A byte array containing the S7 date time representations of <paramref name="timeSpans"/>.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when any value of
-        ///   <paramref name="timeSpans"/> is before <see cref="P:SpecMinimumDateTime"/>
-        ///   or after <see cref="P:SpecMaximumDateTime"/>.</exception>
+        ///   <paramref name="timeSpans"/> is before <see cref="P:SpecMinimumTimeSpan"/>
+        ///   or after <see cref="P:SpecMaximumTimeSpan"/>.</exception>
         public static byte[] ToByteArray(System.TimeSpan[] timeSpans)
         {
             var bytes = new List<byte>(timeSpans.Length * 4);

--- a/S7.Net/Types/TimeSpan.cs
+++ b/S7.Net/Types/TimeSpan.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+
+namespace S7.Net.Types
+{
+    public static class TimeSpan
+    {
+        /// <summary>
+        /// The minimum <see cref="T:System.TimeSpan"/> value supported by the specification.
+        /// </summary>
+        public static readonly System.TimeSpan SpecMinimumTimeSpan = System.TimeSpan.FromMilliseconds(int.MinValue);
+
+        /// <summary>
+        /// The maximum <see cref="T:System.TimeSpan"/> value supported by the specification.
+        /// </summary>
+        public static readonly System.TimeSpan SpecMaximumTimeSpan = System.TimeSpan.FromMilliseconds(int.MaxValue);
+
+        /// <summary>
+        /// Parses a <see cref="T:System.TimeSpan"/> value from bytes.
+        /// </summary>
+        /// <param name="bytes">Input bytes read from PLC.</param>
+        /// <returns>A <see cref="T:System.TimeSpan"/> object representing the value read from PLC.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the length of
+        ///   <paramref name="bytes"/> is not 4 or any value in <paramref name="bytes"/>
+        ///   is outside the valid range of values.</exception>
+        public static System.TimeSpan FromByteArray(byte[] bytes)
+        {
+            var milliseconds = DInt.FromByteArray(bytes);
+            return System.TimeSpan.FromMilliseconds(milliseconds);
+        }
+
+        /// <summary>
+        /// Parses an array of <see cref="T:System.TimeSpan"/> values from bytes.
+        /// </summary>
+        /// <param name="bytes">Input bytes read from PLC.</param>
+        /// <returns>An array of <see cref="T:System.TimeSpan"/> objects representing the values read from PLC.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the length of
+        ///   <paramref name="bytes"/> is not a multiple of 4 or any value in
+        ///   <paramref name="bytes"/> is outside the valid range of values.</exception>
+        public static System.TimeSpan[] ToArray(byte[] bytes)
+        {
+            const int singleTimeSpanLength = 4;
+            
+            if (bytes.Length % singleTimeSpanLength != 0)
+                throw new ArgumentOutOfRangeException(nameof(bytes), bytes.Length,
+                    $"Parsing an array of {nameof(System.TimeSpan)} requires a multiple of {singleTimeSpanLength} bytes of input data, input data is '{bytes.Length}' long.");
+
+            var cnt = bytes.Length / singleTimeSpanLength;
+            var result = new System.TimeSpan[bytes.Length / singleTimeSpanLength];
+
+            var milliseconds = DInt.ToArray(bytes);
+            for (var i = 0; i < milliseconds.Length; i++)
+                result[i] = System.TimeSpan.FromMilliseconds(milliseconds[i]);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="T:System.DateTime"/> value to a byte array.
+        /// </summary>
+        /// <param name="timeSpan">The DateTime value to convert.</param>
+        /// <returns>A byte array containing the S7 date time representation of <paramref name="timeSpan"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the value of
+        ///   <paramref name="timeSpan"/> is before <see cref="P:SpecMinimumDateTime"/>
+        ///   or after <see cref="P:SpecMaximumDateTime"/>.</exception>
+        public static byte[] ToByteArray(System.TimeSpan timeSpan)
+        {
+            if (timeSpan < SpecMinimumTimeSpan)
+                throw new ArgumentOutOfRangeException(nameof(timeSpan), timeSpan,
+                    $"Time span '{timeSpan}' is before the minimum '{SpecMinimumTimeSpan}' supported in S7 time representation.");
+
+            if (timeSpan > SpecMaximumTimeSpan)
+                throw new ArgumentOutOfRangeException(nameof(timeSpan), timeSpan,
+                    $"Time span '{timeSpan}' is after the maximum '{SpecMaximumTimeSpan}' supported in S7 time representation.");
+
+            return DInt.ToByteArray(Convert.ToInt32(timeSpan.TotalMilliseconds));
+        }
+
+        /// <summary>
+        /// Converts an array of <see cref="T:System.DateTime"/> values to a byte array.
+        /// </summary>
+        /// <param name="timeSpans">The DateTime values to convert.</param>
+        /// <returns>A byte array containing the S7 date time representations of <paramref name="dateTime"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when any value of
+        ///   <paramref name="timeSpans"/> is before <see cref="P:SpecMinimumDateTime"/>
+        ///   or after <see cref="P:SpecMaximumDateTime"/>.</exception>
+        public static byte[] ToByteArray(System.TimeSpan[] timeSpans)
+        {
+            var bytes = new List<byte>(timeSpans.Length * 4);
+            foreach (var timeSpan in timeSpans) bytes.AddRange(ToByteArray(timeSpan));
+
+            return bytes.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
TimeSpan can now be serialized to S7 Time (IEC), which is 4 bytes long.
The serialization works in structs too.
Tested on S7-1200.