### PR TITLE
Return expected length substring rather than throw an exception when reading strings.

### DIFF
--- a/S7.Net.UnitTest/ConvertersUnitTest.cs
+++ b/S7.Net.UnitTest/ConvertersUnitTest.cs
@@ -22,7 +22,22 @@ namespace S7.Net.UnitTest
             Assert.IsFalse(dummyByte.SelectBit(5));
             Assert.IsFalse(dummyByte.SelectBit(6));
             Assert.IsFalse(dummyByte.SelectBit(7));
+        }
 
+        [TestMethod]
+        public void T01_TestSetBit()
+        {
+            byte dummyByte = 0xAA; // 1010 1010
+            dummyByte.SetBit(0, true);
+            dummyByte.SetBit(1, false);
+            dummyByte.SetBit(2, true);
+            dummyByte.SetBit(3, false);
+            Assert.AreEqual<byte>(dummyByte, 0xA5);// 1010 0101
+            dummyByte.SetBit(4, true);
+            dummyByte.SetBit(5, true);
+            dummyByte.SetBit(6, true);
+            dummyByte.SetBit(7, true);
+            Assert.AreEqual<byte>(dummyByte, 0xF5);// 1111 0101
         }
     }
 }

--- a/S7.Net/Conversion.cs
+++ b/S7.Net/Conversion.cs
@@ -152,6 +152,51 @@ namespace S7.Net
         }
 
         /// <summary>
+        /// Helper to set a bit value to the given byte at the bit index.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="bitPosition"></param>
+        /// <param name="value"></param>
+        public static void SetBit(this ref byte data, int bitPosition, bool value)
+        {
+            if (bitPosition < 0 || bitPosition > 7)
+            {
+                return;
+            }
+
+            if (value)
+            {
+                switch (bitPosition)
+                {
+                    case 0: data |= 0x01; return;
+                    case 1: data |= 0x02; return;
+                    case 2: data |= 0x04; return;
+                    case 3: data |= 0x08; return;
+                    case 4: data |= 0x10; return;
+                    case 5: data |= 0x20; return;
+                    case 6: data |= 0x40; return;
+                    case 7: data |= 0x80; return;
+                    default: return;
+                }
+            }
+            else
+            {
+                switch (bitPosition)
+                {
+                    case 0: data &= 0xFE; return;
+                    case 1: data &= 0xFD; return;
+                    case 2: data &= 0xFB; return;
+                    case 3: data &= 0xF7; return;
+                    case 4: data &= 0xEF; return;
+                    case 5: data &= 0xDF; return;
+                    case 6: data &= 0xBF; return;
+                    case 7: data &= 0x7F; return;
+                    default: return;
+                }
+            }
+        }
+
+        /// <summary>
         /// Converts from ushort value to short value; it's used to retrieve negative values from words
         /// </summary>
         /// <param name="input"></param>

--- a/S7.Net/Types/S7String.cs
+++ b/S7.Net/Types/S7String.cs
@@ -42,7 +42,8 @@ namespace S7.Net.Types
 
             try
             {
-                return StringEncoding.GetString(bytes, 2, length);
+                int expect_length = bytes.Length - 2;
+                return StringEncoding.GetString(bytes, 2, Math.Min(expect_length, length));
             }
             catch (Exception e)
             {

--- a/S7.Net/Types/S7WString.cs
+++ b/S7.Net/Types/S7WString.cs
@@ -31,7 +31,8 @@ namespace S7.Net.Types
 
             try
             {
-                return Encoding.BigEndianUnicode.GetString(bytes, 4, length * 2);
+                int expect_length = (bytes.Length - 4) / 2;
+                return Encoding.BigEndianUnicode.GetString(bytes, 4, Math.Min(expect_length, length) * 2);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Sometimes users just want to read a part of the string, but if your count parameter is less than the string's length, it will cause an exception.