### PR TITLE
Return expected length substring rather than throw an exception when reading strings

### DIFF
--- a/S7.Net/Types/S7String.cs
+++ b/S7.Net/Types/S7String.cs
@@ -42,7 +42,8 @@ namespace S7.Net.Types
 
             try
             {
-                return StringEncoding.GetString(bytes, 2, length);
+                int expect_length = bytes.Length - 2;
+                return StringEncoding.GetString(bytes, 2, Math.Min(expect_length, length));
             }
             catch (Exception e)
             {

--- a/S7.Net/Types/S7WString.cs
+++ b/S7.Net/Types/S7WString.cs
@@ -31,7 +31,8 @@ namespace S7.Net.Types
 
             try
             {
-                return Encoding.BigEndianUnicode.GetString(bytes, 4, length * 2);
+                int expect_length = (bytes.Length - 4) / 2;
+                return Encoding.BigEndianUnicode.GetString(bytes, 4, Math.Min(expect_length, length) * 2);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Return expected length substring rather than throw an exception when reading strings