### PR TITLE
Add support for reading/writing the legacy DATE (IEC date) datatype

### DIFF
--- a/S7.Net/Enums.cs
+++ b/S7.Net/Enums.cs
@@ -202,6 +202,11 @@
         /// DateTIme variable type
         /// </summary>
         DateTime,
+        
+        /// <summary>
+        /// IEC date (legacy) variable type
+        /// </summary>
+        Date,
 
         /// <summary>
         /// DateTimeLong variable type

--- a/S7.Net/Helper/DateTimeExtensions.cs
+++ b/S7.Net/Helper/DateTimeExtensions.cs
@@ -10,11 +10,11 @@ namespace S7.Net.Helper
         {
             if (dateTime < Date.IecMinDate)
             {
-                throw new ArgumentException($"DateTime must be at least {Date.IecMinDate:d}");
+                throw new ArgumentOutOfRangeException($"DateTime must be at least {Date.IecMinDate:d}");
             }
             if (dateTime > Date.IecMaxDate)
             {
-                throw new ArgumentException($"DateTime must be lower than {Date.IecMaxDate:d}");
+                throw new ArgumentOutOfRangeException($"DateTime must be lower than {Date.IecMaxDate:d}");
             }
 
             return (ushort)(dateTime - Date.IecMinDate).TotalDays;

--- a/S7.Net/Helper/DateTimeExtensions.cs
+++ b/S7.Net/Helper/DateTimeExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using S7.Net.Types;
+using DateTime = System.DateTime;
+
+namespace S7.Net.Helper
+{
+    public static class DateTimeExtensions
+    {
+        public static ushort GetDaysSinceIecDateStart(this DateTime dateTime)
+        {
+            if (dateTime < Date.IecMinDate)
+            {
+                throw new ArgumentException($"DateTime must be at least {Date.IecMinDate:d}");
+            }
+            if (dateTime > Date.IecMaxDate)
+            {
+                throw new ArgumentException($"DateTime must be lower than {Date.IecMaxDate:d}");
+            }
+
+            return (ushort)(dateTime - Date.IecMinDate).TotalDays;
+        }
+    }
+}

--- a/S7.Net/PLCHelpers.cs
+++ b/S7.Net/PLCHelpers.cs
@@ -244,6 +244,15 @@ namespace S7.Net
                     {
                         return TimeSpan.ToArray(bytes);
                     }
+                case VarType.Date:
+                    if (varCount == 1)
+                    {
+                        return Date.FromByteArray(bytes);
+                    }
+                    else
+                    {
+                        return Date.ToArray(bytes);
+                    }
                 default:
                     return null;
             }
@@ -273,6 +282,7 @@ namespace S7.Net
                 case VarType.Timer:
                 case VarType.Int:
                 case VarType.Counter:
+                case VarType.Date:
                     return varCount * 2;
                 case VarType.DWord:
                 case VarType.DInt:

--- a/S7.Net/Protocol/Serialization.cs
+++ b/S7.Net/Protocol/Serialization.cs
@@ -26,6 +26,11 @@ namespace S7.Net.Protocol
                     _ => Types.String.ToByteArray(s, dataItem.Count)
                 };
 
+            if (dataItem.VarType == VarType.Date)
+            {
+                return Date.ToByteArray((System.DateTime)dataItem.Value);
+            }
+
             return SerializeValue(dataItem.Value);
         }
 

--- a/S7.Net/Types/Date.cs
+++ b/S7.Net/Types/Date.cs
@@ -15,8 +15,14 @@ namespace S7.Net.Types
         
         /// <summary>
         /// Maximum allowed date for the IEC date type
+        /// <remarks>
+        /// Although the spec allows only a max date of 31-12-2168, the PLC IEC date goes up to 06-06-2169 (which is the actual
+        /// WORD max value - 65535) 
+        /// </remarks>
         /// </summary>
-        public static readonly System.DateTime IecMaxDate = new(year: 2168, month: 12, day: 31);
+        public static readonly System.DateTime IecMaxDate = new(year: 2169, month: 06, day: 06);
+        
+        private static readonly ushort MaxNumberOfDays = (ushort)(IecMaxDate - IecMinDate).TotalDays;
         
         /// <summary>
         /// Converts a word (2 bytes) to IEC date (<see cref="System.DateTime"/>)
@@ -29,6 +35,12 @@ namespace S7.Net.Types
             }
 
             var daysSinceDateStart = Word.FromByteArray(bytes);
+            if (daysSinceDateStart > MaxNumberOfDays)
+            {
+                throw new ArgumentException($"Read number exceeded the number of maximum days in the IEC date (read: {daysSinceDateStart}, max: {MaxNumberOfDays})", 
+                    nameof(bytes));
+            }
+            
             return IecMinDate.AddDays(daysSinceDateStart);
         }
 

--- a/S7.Net/Types/Date.cs
+++ b/S7.Net/Types/Date.cs
@@ -1,0 +1,70 @@
+using System;
+using S7.Net.Helper;
+
+namespace S7.Net.Types
+{
+    /// <summary>
+    /// Contains the conversion methods to convert Words from S7 plc to C#.
+    /// </summary>
+    public static class Date
+    {
+        /// <summary>
+        /// Minimum allowed date for the IEC date type
+        /// </summary>
+        public static readonly System.DateTime IecMinDate = new(year: 1990, month: 01, day: 01);
+        
+        /// <summary>
+        /// Maximum allowed date for the IEC date type
+        /// </summary>
+        public static readonly System.DateTime IecMaxDate = new(year: 2168, month: 12, day: 31);
+        
+        /// <summary>
+        /// Converts a word (2 bytes) to IEC date (<see cref="System.DateTime"/>)
+        /// </summary>
+        public static System.DateTime FromByteArray(byte[] bytes)
+        {
+            if (bytes.Length != 2)
+            {
+                throw new ArgumentException("Wrong number of bytes. Bytes array must contain 2 bytes.");
+            }
+
+            var daysSinceDateStart = Word.FromByteArray(bytes);
+            return IecMinDate.AddDays(daysSinceDateStart);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="System.DateTime"/> to word (2 bytes)
+        /// </summary>
+        public static byte[] ToByteArray(System.DateTime dateTime) => Word.ToByteArray(dateTime.GetDaysSinceIecDateStart());
+
+        /// <summary>
+        /// Converts an array of <see cref="System.DateTime"/>s to an array of bytes
+        /// </summary>
+        public static byte[] ToByteArray(System.DateTime[] value)
+        {
+            var arr = new ByteArray();
+            foreach (var date in value)
+                arr.Add(ToByteArray(date));
+            return arr.Array;
+        }
+
+        /// <summary>
+        /// Converts an array of bytes to an array of <see cref="System.DateTime"/>s
+        /// </summary>
+        public static System.DateTime[] ToArray(byte[] bytes)
+        {
+            var values = new System.DateTime[bytes.Length / sizeof(ushort)];
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = FromByteArray(
+                    new[]
+                    {
+                        bytes[i], bytes[i + 1]
+                    });
+            }
+
+            return values;
+        }
+    }
+}

--- a/S7.Net/Types/Date.cs
+++ b/S7.Net/Types/Date.cs
@@ -11,7 +11,7 @@ namespace S7.Net.Types
         /// <summary>
         /// Minimum allowed date for the IEC date type
         /// </summary>
-        public static readonly System.DateTime IecMinDate = new(year: 1990, month: 01, day: 01);
+        public static System.DateTime IecMinDate { get; } = new(year: 1990, month: 01, day: 01);
         
         /// <summary>
         /// Maximum allowed date for the IEC date type
@@ -20,7 +20,7 @@ namespace S7.Net.Types
         /// WORD max value - 65535) 
         /// </remarks>
         /// </summary>
-        public static readonly System.DateTime IecMaxDate = new(year: 2169, month: 06, day: 06);
+        public static System.DateTime IecMaxDate { get; } = new(year: 2169, month: 06, day: 06);
         
         private static readonly ushort MaxNumberOfDays = (ushort)(IecMaxDate - IecMinDate).TotalDays;
         


### PR DESCRIPTION
Solves #505 

I did not bother with adding this type to struct serialization, because the DateTime type itself is not supported either.
I might create a separate PR and add both the DateTime and IEC date to struct later on.